### PR TITLE
DNM - Paused Composer

### DIFF
--- a/Convos/Conversation Detail/AgentDmPageView.swift
+++ b/Convos/Conversation Detail/AgentDmPageView.swift
@@ -28,6 +28,14 @@ struct AgentDmPageView: View {
     /// Mirrors ConversationView's effectiveReadOnly: a removed or stale
     /// device must not be able to send into agent DMs.
     let isReadOnly: Bool
+    /// True when the conversation's agent participation is paused. The DM's send
+    /// button then shows the paused visual, sends are blocked, and the composer
+    /// hint changes; a blocked attempt raises the paused alert.
+    var sendButtonPaused: Bool = false
+    /// Resumes the agent (participation -> speak freely) from the paused alert's
+    /// Unpause action. Owned by ConversationView, which holds the participation
+    /// store the DM page can't reach.
+    var onUnpauseAgent: () -> Void = {}
     /// True while the Agent tab is the selected tab. The backing views stay
     /// mounted across tab switches, so activation drives the read state and
     /// the active-DM push lane. (Composer focus transfers are owned by
@@ -61,6 +69,7 @@ struct AgentDmPageView: View {
     private var agentName: String { session.agentName }
 
     @State private var emptyStateSettled: Bool = false
+    @State private var showingPausedAgentAlert: Bool = false
 
     /// Centred over the page and faded rather than inserted into the list, so
     /// it never holds a scroll position. Never takes hits - it is only text.
@@ -300,6 +309,9 @@ struct AgentDmPageView: View {
 
     private func dmMessagesView(_ dmVm: ConversationViewModel) -> some View {
         @Bindable var dmVm = dmVm
+        let messagePlaceholder: String = sendButtonPaused
+            ? "\(agentName) is paused"
+            : "Chat with \(agentName)"
         return MessagesView(
             contextMenuState: contextMenuState,
             conversation: dmVm.conversation,
@@ -313,7 +325,7 @@ struct AgentDmPageView: View {
             conversationImage: $dmVm.conversationImage,
             displayName: $dmVm.myProfileViewModel.editingDisplayName,
             messageText: $dmVm.messageText,
-            messagePlaceholder: "Chat with \(agentName)",
+            messagePlaceholder: messagePlaceholder,
             pendingMediaAttachments: dmVm.pendingMediaAttachments,
             composerLinkPreview: dmVm.pastedLinkPreview,
             pendingInviteURL: dmVm.pendingInvite?.fullURL,
@@ -325,6 +337,8 @@ struct AgentDmPageView: View {
             isShowingAgentShareChip: dmVm.pendingAgentShare != nil,
             onClearAgentShare: dmVm.clearPendingAgentShare,
             sendButtonEnabled: dmVm.sendButtonEnabled,
+            sendButtonPaused: sendButtonPaused,
+            onPausedSendTap: { showingPausedAgentAlert = true },
             profileImage: $dmVm.myProfileViewModel.profileImage,
             onboardingCoordinator: dmVm.onboardingCoordinator,
             focusState: $focusState,
@@ -449,6 +463,12 @@ struct AgentDmPageView: View {
             }
             .selfSizingSheet(isPresented: $dmVm.presentingCapabilityApproval) {
                 capabilityApprovalSheet(for: dmVm)
+            }
+            .alert("Agent is paused", isPresented: $showingPausedAgentAlert) {
+                Button("Unpause") { onUnpauseAgent() }
+                Button("Not now", role: .cancel) {}
+            } message: {
+                Text("\(agentName) is paused and won't see new messages right now.")
             }
     }
 

--- a/Convos/Conversation Detail/AgentDmPageView.swift
+++ b/Convos/Conversation Detail/AgentDmPageView.swift
@@ -112,6 +112,17 @@ struct AgentDmPageView: View {
             emptyStateSettled = true
         }
         .environment(\.colorScheme, .dark)
+        // Attached outside the forced-dark environment above: the system presents
+        // the alert chrome in the device's real appearance, so inheriting `.dark`
+        // here would render the buttons' text for dark mode (white) over a light
+        // alert. Keeping it outside lets the alert follow the app appearance the
+        // way the group transcript's alerts do.
+        .alert("\(agentName) is paused", isPresented: $showingPausedAgentAlert) {
+            Button("Unpause") { onUnpauseAgent() }
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Paused agents cannot see new groupchat messages or receive new 1:1 messages.")
+        }
         // The agent-participation ("listen") control governs how much agents
         // speak in the group room; it has no meaning in a 1:1 agent DM, so clear
         // the inherited participation context to hide the control here.
@@ -463,12 +474,6 @@ struct AgentDmPageView: View {
             }
             .selfSizingSheet(isPresented: $dmVm.presentingCapabilityApproval) {
                 capabilityApprovalSheet(for: dmVm)
-            }
-            .alert("\(agentName) is paused", isPresented: $showingPausedAgentAlert) {
-                Button("Unpause") { onUnpauseAgent() }
-                Button("OK", role: .cancel) {}
-            } message: {
-                Text("Paused agents cannot see new groupchat messages or receive new 1:1 messages.")
             }
     }
 

--- a/Convos/Conversation Detail/AgentDmPageView.swift
+++ b/Convos/Conversation Detail/AgentDmPageView.swift
@@ -1,6 +1,7 @@
 import ConvosComposer
 import ConvosCore
 import SwiftUI
+import UIKit
 
 /// The Agent tab's backing view: the user's private DM with the
 /// conversation's agent, rendered behind the conversation sheet. The DM is a
@@ -112,16 +113,18 @@ struct AgentDmPageView: View {
             emptyStateSettled = true
         }
         .environment(\.colorScheme, .dark)
-        // Attached outside the forced-dark environment above: the system presents
-        // the alert chrome in the device's real appearance, so inheriting `.dark`
-        // here would render the buttons' text for dark mode (white) over a light
-        // alert. Keeping it outside lets the alert follow the app appearance the
-        // way the group transcript's alerts do.
-        .alert("\(agentName) is paused", isPresented: $showingPausedAgentAlert) {
-            Button("Unpause") { onUnpauseAgent() }
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text("Paused agents cannot see new groupchat messages or receive new 1:1 messages.")
+        // A SwiftUI .alert takes its button color from the presenting
+        // controller's tintColor, not the local `\.tint`, so on the agent tab -
+        // forced dark by ScreenAppearanceScope, where the app's colorTextPrimary
+        // tint resolves to white - the buttons read white on the light system
+        // alert. Present a UIKit alert we control instead, pinned to a light
+        // appearance so title, message, and buttons all read dark.
+        .background {
+            PausedAgentAlert(
+                isPresented: $showingPausedAgentAlert,
+                agentName: agentName,
+                onUnpause: onUnpauseAgent
+            )
         }
         // The agent-participation ("listen") control governs how much agents
         // speak in the group room; it has no meaning in a 1:1 agent DM, so clear
@@ -589,5 +592,64 @@ struct AgentDmPageView: View {
         static let progressWidth: CGFloat = 120.0
         static let progressHeight: CGFloat = 8.0
         static let progressTrackOpacity: Double = 0.3
+    }
+}
+
+/// Presents the paused-agent alert as a UIKit `UIAlertController` we fully
+/// control. A SwiftUI `.alert` inherits its button color from the presenting
+/// controller's tintColor, which on the agent tab is forced dark
+/// (ScreenAppearanceScope) - the app's colorTextPrimary tint resolves to white,
+/// so the buttons read white on the light system alert. Pinning the alert to a
+/// light appearance and tinting it with colorTextPrimary keeps title, message,
+/// and buttons all dark. Embedded as a zero-size background so it never draws.
+private struct PausedAgentAlert: UIViewControllerRepresentable {
+    @Binding var isPresented: Bool
+    let agentName: String
+    let onUnpause: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        UIViewController()
+    }
+
+    func updateUIViewController(_ host: UIViewController, context: Context) {
+        let coordinator = context.coordinator
+        guard isPresented else {
+            if let alert = coordinator.alert {
+                coordinator.alert = nil
+                alert.dismiss(animated: true)
+            }
+            return
+        }
+        guard coordinator.alert == nil, host.presentedViewController == nil else { return }
+        let alert = UIAlertController(
+            title: "\(agentName) is paused",
+            message: "Paused agents can't receive 1:1 messages nor see anything new in the groupchat",
+            preferredStyle: .alert
+        )
+        alert.overrideUserInterfaceStyle = .light
+        let okAction = UIAlertAction(title: "OK", style: .default) { _ in
+            coordinator.alert = nil
+            isPresented = false
+        }
+        alert.addAction(okAction)
+        alert.addAction(UIAlertAction(title: "Unpause", style: .default) { _ in
+            coordinator.alert = nil
+            isPresented = false
+            onUnpause()
+        })
+        // OK is the emphasized action: the preferred action renders filled with
+        // the tint (black here) and white text, leaving Unpause the plain button.
+        alert.preferredAction = okAction
+        coordinator.alert = alert
+        host.present(alert, animated: true)
+        alert.view.tintColor = UIColor(named: "colorTextPrimary") ?? .label
+    }
+
+    final class Coordinator {
+        weak var alert: UIAlertController?
     }
 }

--- a/Convos/Conversation Detail/AgentDmPageView.swift
+++ b/Convos/Conversation Detail/AgentDmPageView.swift
@@ -464,11 +464,11 @@ struct AgentDmPageView: View {
             .selfSizingSheet(isPresented: $dmVm.presentingCapabilityApproval) {
                 capabilityApprovalSheet(for: dmVm)
             }
-            .alert("Agent is paused", isPresented: $showingPausedAgentAlert) {
+            .alert("\(agentName) is paused", isPresented: $showingPausedAgentAlert) {
                 Button("Unpause") { onUnpauseAgent() }
-                Button("Not now", role: .cancel) {}
+                Button("OK", role: .cancel) {}
             } message: {
-                Text("\(agentName) is paused and won't see new messages right now.")
+                Text("Paused agents cannot see new groupchat messages or receive new 1:1 messages.")
             }
     }
 

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1456,7 +1456,9 @@ private extension ConversationView {
                 isReadOnly: effectiveReadOnly,
                 sendButtonPaused: participation?.level == .paused,
                 onUnpauseAgent: {
-                    guard let participation else { return }
+                    // A removed or stale (read-only) device must not be able to
+                    // change participation, same gate as the composer's sends.
+                    guard !effectiveReadOnly, let participation else { return }
                     Task { await participation.set(.speakFreely) }
                 },
                 isActiveTab: isActive,

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1454,6 +1454,11 @@ private extension ConversationView {
                 connectionsEnabled: composerConnectionsEnabled,
                 onConnectionsTap: handleComposerConnectionsTap,
                 isReadOnly: effectiveReadOnly,
+                sendButtonPaused: participation?.level == .paused,
+                onUnpauseAgent: {
+                    guard let participation else { return }
+                    Task { await participation.set(.speakFreely) }
+                },
                 isActiveTab: isActive,
                 contextMenuState: agentContextMenuState,
                 focusState: $agentFocus,

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1459,7 +1459,8 @@ private extension ConversationView {
                     // A removed or stale (read-only) device must not be able to
                     // change participation, same gate as the composer's sends.
                     guard !effectiveReadOnly, let participation else { return }
-                    Task { await participation.set(.speakFreely) }
+                    // Unpause resumes into listen mode, not full speak-freely.
+                    Task { await participation.set(.mentionsOnly) }
                 },
                 isActiveTab: isActive,
                 contextMenuState: agentContextMenuState,

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -45,6 +45,11 @@ struct MessagesView<BottomBarContent: View>: View {
     var isShowingAgentShareChip: Bool = false
     var onClearAgentShare: (() -> Void)?
     let sendButtonEnabled: Bool
+    /// When true the composer's send button shows the paused visual and every
+    /// send path is blocked; taps route to `onPausedSendTap`. Set by the agent
+    /// DM when the agent's participation is paused.
+    var sendButtonPaused: Bool = false
+    var onPausedSendTap: () -> Void = {}
     @Binding var profileImage: UIImage?
     let onboardingCoordinator: ConversationOnboardingCoordinator
     @FocusState.Binding var focusState: MessagesViewInputFocus?
@@ -316,6 +321,8 @@ struct MessagesView<BottomBarContent: View>: View {
                     onInviteConvoNameEditingEnded: onInviteConvoNameEditingEnded,
                     isShowingAgentShareChip: isShowingAgentShareChip,
                     sendButtonEnabled: sendButtonEnabled,
+                    sendButtonPaused: sendButtonPaused,
+                    onPausedSendTap: onPausedSendTap,
                     profileImage: $profileImage,
                     isPhotoPickerPresented: $isPhotoPickerPresented,
                     focusState: $focusState,

--- a/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
@@ -69,6 +69,11 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
     var onInviteConvoNameEditingEnded: ((String) -> Void)?
     var isShowingAgentShareChip: Bool = false
     let sendButtonEnabled: Bool
+    /// When true the send button shows the paused visual, every send path is
+    /// blocked, and taps route to `onPausedSendTap`. Set in the agent DM when
+    /// the agent's participation is paused.
+    var sendButtonPaused: Bool = false
+    var onPausedSendTap: () -> Void = {}
     @Binding var profileImage: UIImage?
     @Binding var isPhotoPickerPresented: Bool
     @FocusState.Binding var focusState: MessagesViewInputFocus?
@@ -148,6 +153,8 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         onInviteConvoNameEditingEnded: ((String) -> Void)? = nil,
         isShowingAgentShareChip: Bool = false,
         sendButtonEnabled: Bool,
+        sendButtonPaused: Bool = false,
+        onPausedSendTap: @escaping () -> Void = {},
         profileImage: Binding<UIImage?>,
         isPhotoPickerPresented: Binding<Bool>,
         focusState: FocusState<MessagesViewInputFocus?>.Binding,
@@ -192,6 +199,8 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         self.onInviteConvoNameEditingEnded = onInviteConvoNameEditingEnded
         self.isShowingAgentShareChip = isShowingAgentShareChip
         self.sendButtonEnabled = sendButtonEnabled
+        self.sendButtonPaused = sendButtonPaused
+        self.onPausedSendTap = onPausedSendTap
         _profileImage = profileImage
         _isPhotoPickerPresented = isPhotoPickerPresented
         _focusState = focusState
@@ -556,7 +565,7 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         if isMediaCapacityFull || hasSideConvo {
             disabled.formUnion([.photos, .camera, .files])
         }
-        if hasMedia || hasSideConvo {
+        if hasMedia || hasSideConvo || sendButtonPaused {
             disabled.insert(.voiceNote)
         }
         return disabled
@@ -612,7 +621,7 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
     /// typed property so the solver never has to resolve a conditional
     /// optional closure inside `MessagesInputView`'s argument list.
     private var voiceMemoTapWhenEmpty: (() -> Void)? {
-        guard usesAgentComposerLayout else { return nil }
+        guard usesAgentComposerLayout, !sendButtonPaused else { return nil }
         return { startVoiceMemoRecording() }
     }
 
@@ -648,6 +657,8 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
             onInviteConvoNameEditingEnded: onInviteConvoNameEditingEnded,
             isShowingAgentShareChip: isShowingAgentShareChip,
             sendButtonEnabled: sendButtonEnabled,
+            sendButtonPaused: sendButtonPaused,
+            onPausedSendTap: onPausedSendTap,
             focusState: $focusState,
             messagesTextFieldEnabled: messagesTextFieldEnabled,
             onSendMessage: onSendMessage,

--- a/ConvosCore/Sources/ConvosComposer/MessagesInputView.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesInputView.swift
@@ -24,6 +24,13 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View, AttachmentsB
     var onInviteConvoNameEditingEnded: ((String) -> Void)?
     var isShowingAgentShareChip: Bool = false
     let sendButtonEnabled: Bool
+    /// When true the send button shows a pause glyph in the disabled visual but
+    /// stays tappable, sending is blocked, and taps fire `onPausedSendTap`. Used
+    /// in the agent DM when the agent's participation is paused.
+    var sendButtonPaused: Bool = false
+    /// Fired when a send is attempted while `sendButtonPaused` - the send button
+    /// tap and the return key both route here instead of `onSendMessage`.
+    var onPausedSendTap: () -> Void = {}
     @FocusState.Binding var focusState: MessagesViewInputFocus?
     let messagesTextFieldEnabled: Bool
     private let focused: MessagesViewInputFocus = .message
@@ -66,6 +73,8 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View, AttachmentsB
         onInviteConvoNameEditingEnded: ((String) -> Void)? = nil,
         isShowingAgentShareChip: Bool = false,
         sendButtonEnabled: Bool,
+        sendButtonPaused: Bool = false,
+        onPausedSendTap: @escaping () -> Void = {},
         focusState: FocusState<MessagesViewInputFocus?>.Binding,
         messagesTextFieldEnabled: Bool,
         onSendMessage: @escaping () -> Void,
@@ -93,6 +102,8 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View, AttachmentsB
         self.onInviteConvoNameEditingEnded = onInviteConvoNameEditingEnded
         self.isShowingAgentShareChip = isShowingAgentShareChip
         self.sendButtonEnabled = sendButtonEnabled
+        self.sendButtonPaused = sendButtonPaused
+        self.onPausedSendTap = onPausedSendTap
         _focusState = focusState
         self.messagesTextFieldEnabled = messagesTextFieldEnabled
         self.onSendMessage = onSendMessage
@@ -124,9 +135,11 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View, AttachmentsB
     /// host opted in.
     @ViewBuilder
     private var trailingButton: some View {
-        if let onVoiceMemoTapWhenEmpty,
-           messageText.isEmpty,
-           !hasAttachments {
+        if sendButtonPaused {
+            sendButton
+        } else if let onVoiceMemoTapWhenEmpty,
+                  messageText.isEmpty,
+                  !hasAttachments {
             voiceMemoButton(action: onVoiceMemoTapWhenEmpty)
         } else {
             sendButton
@@ -152,22 +165,27 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View, AttachmentsB
     }
 
     private var sendButton: some View {
-        Button {
-            onSendMessage()
-        } label: {
-            Image(systemName: "arrow.up")
+        let usesFilledStyle: Bool = !sendButtonPaused && sendButtonEnabled
+        let glyphName: String = sendButtonPaused ? "pause.fill" : "arrow.up"
+        let tintColor: Color = usesFilledStyle ? .colorTextPrimaryInverted : .colorTextPrimary
+        let backgroundColor: Color = usesFilledStyle ? .colorFillPrimary : .colorFillMinimal
+        let interactionDisabled: Bool = !sendButtonPaused && !sendButtonEnabled
+        let action: () -> Void = sendButtonPaused ? onPausedSendTap : onSendMessage
+        let a11yLabel: String = sendButtonPaused ? "Agent paused" : "Send message"
+        return Button(action: action) {
+            Image(systemName: glyphName)
                 .symbolEffect(.bounce.up.byLayer, options: .nonRepeating)
                 .frame(width: sendButtonSize, height: sendButtonSize, alignment: .center)
-                .tint(sendButtonEnabled ? .colorTextPrimaryInverted : .colorTextPrimary)
+                .tint(tintColor)
                 .font(.callout.weight(.medium))
         }
-        .background(sendButtonEnabled ? .colorFillPrimary : .colorFillMinimal)
+        .background(backgroundColor)
         .mask(Circle())
         .frame(width: sendButtonSize, height: sendButtonSize, alignment: .bottomLeading)
         .hoverEffect(.lift)
-        .hoverEffectDisabled(!sendButtonEnabled)
-        .disabled(!sendButtonEnabled)
-        .accessibilityLabel("Send message")
+        .hoverEffectDisabled(interactionDisabled)
+        .disabled(interactionDisabled)
+        .accessibilityLabel(a11yLabel)
         .accessibilityIdentifier("send-message-button")
     }
 
@@ -190,8 +208,12 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View, AttachmentsB
             .accessibilityIdentifier("message-text-field")
         }
         .onSubmit {
-            onSendMessage()
-            focusState = .message
+            if sendButtonPaused {
+                onPausedSendTap()
+            } else {
+                onSendMessage()
+                focusState = .message
+            }
         }
         .frame(maxHeight: .infinity, alignment: .center)
     }

--- a/ConvosCore/Sources/ConvosComposer/MessagesInputView.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesInputView.swift
@@ -165,10 +165,19 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View, AttachmentsB
     }
 
     private var sendButton: some View {
-        let usesFilledStyle: Bool = !sendButtonPaused && sendButtonEnabled
         let glyphName: String = sendButtonPaused ? "pause.fill" : "arrow.up"
-        let tintColor: Color = usesFilledStyle ? .colorTextPrimaryInverted : .colorTextPrimary
-        let backgroundColor: Color = usesFilledStyle ? .colorFillPrimary : .colorFillMinimal
+        let tintColor: Color
+        let backgroundColor: Color
+        if sendButtonPaused {
+            tintColor = .colorFillMinimal
+            backgroundColor = .colorFillTertiary
+        } else if sendButtonEnabled {
+            tintColor = .colorTextPrimaryInverted
+            backgroundColor = .colorFillPrimary
+        } else {
+            tintColor = .colorTextPrimary
+            backgroundColor = .colorFillMinimal
+        }
         let interactionDisabled: Bool = !sendButtonPaused && !sendButtonEnabled
         let action: () -> Void = sendButtonPaused ? onPausedSendTap : onSendMessage
         let a11yLabel: String = sendButtonPaused ? "Agent paused" : "Send message"


### PR DESCRIPTION
## What

When an agent's participation is set to **Pause**, the agent DM composer now blocks sending instead of silently dropping messages the agent will never see.

In the **agent DM** (group composer and Share extension are untouched):
- Send button becomes a `pause.fill` glyph in the disabled/minimal visual, but stays tappable.
- Composer hint text reads **"{agent} is paused"** (per design) instead of "Chat with {agent}".
- Every send path is blocked: send button, return key (`.onSubmit`), and voice-memo entry points (empty-composer swap + the `+` menu's voice-note row, now disabled).
- A blocked attempt raises an alert — **"Agent is paused" / "{agent} is paused and won't see new messages right now."** — with **Unpause** (resumes to speak-freely) and **Not now**.

## How

- `sendButtonPaused` + `onPausedSendTap` params thread through `MessagesView` → `MessagesBottomBar` → `MessagesInputView`, all with safe defaults (`false` / no-op), so the group and Share paths are unchanged.
- `AgentDmPageView` receives `sendButtonPaused` + `onUnpauseAgent`, owns the alert, and derives the paused placeholder.
- `ConversationView.agentPage` sources both from its optimistic `AgentParticipationStore` (`participation?.level == .paused`, `set(.speakFreely)` for unpause) — instant on local taps, synced for remote changes, and naturally gated on the participation feature flag.

## Notes for review

- Unpause always resumes to **Chat (speak freely)**; the prior non-paused mode (e.g. Listen) isn't restored, since the store doesn't track it.
- Text field stays editable while paused — only sending is blocked.
- Edge case left as-is: if pause flips while a voice memo is already recorded, the review sheet's send is still live.

## Testing

- `xcodebuild build` (Convos (Dev)) succeeds; SwiftLint `--strict` clean.
- Manual (feature flag on, conversation with an agent): pause on the group tab → Agent tab shows the paused glyph + hint; tapping raises the alert; Unpause restores sending; `+` menu voice-note disabled while paused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789956538&installation_model_id=20076&pr_number=1404&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1404&signature=9caf6172a4de9449237954a5e69e568a4391bb2503c0af6e93f7d47b10715deb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add paused-agent composer state and UIKit unpause alert to `AgentDmPageView`
> - When an agent's participation level is `.paused`, the composer shows a pause-glyph send button with tertiary styling and a placeholder reading "<agent> is paused"; voice memo entry is suppressed.
> - Send attempts (tap or Return key) trigger a new `PausedAgentAlert` — a `UIViewControllerRepresentable` wrapping a `UIAlertController` pinned to light appearance — offering OK and Unpause actions instead of sending.
> - Tapping Unpause in [ConversationView.swift](https://github.com/xmtplabs/convos-ios/pull/1404/files#diff-315e38ca52e75c79370579c65f3a218ca32afe08c50f49e8165bc2d562a1ce58) asynchronously sets participation from `.paused` to `.mentionsOnly` when the device is not read-only.
> - The paused state and tap handler are threaded from `AgentDmPageView` through `MessagesView`, `MessagesBottomBar`, and `MessagesInputView` via new `sendButtonPaused` and `onPausedSendTap` parameters.
> - Risk: the previous SwiftUI `.alert` modifier in `AgentDmPageView` is removed in favor of the UIKit-based `PausedAgentAlert`; any logic that relied on the SwiftUI alert presentation path will no longer fire.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 145c6c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->