### PR TITLE
fix(conversation): keep the Agent tab dark when the conversation is a sheet

### DIFF
--- a/Convos/Conversation Detail/ScreenAppearanceScope.swift
+++ b/Convos/Conversation Detail/ScreenAppearanceScope.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 import UIKit
 
-/// Applies an appearance style to the pushed screen's own view controller,
-/// for the surfaces that resolve against the UIKit trait collection rather
+/// Applies an appearance style to the screen's own view controller - the one
+/// the navigation stack pushed, or the sheet the screen is presented in - for
+/// the surfaces that resolve against the UIKit trait collection rather
 /// than SwiftUI's `colorScheme` environment: the transcript's collection view
 /// and its cells, glass and material effects, and the keyboard.
 ///
@@ -42,13 +43,40 @@ struct ScreenAppearanceScope: UIViewControllerRepresentable {
             applyStyle()
         }
 
+        private var ancestors: [UIViewController] {
+            Array(sequence(first: self as UIViewController) { $0.parent })
+        }
+
         /// The controller the navigation stack pushed, so the whole screen is
         /// styled and the override is popped along with it. Falls back to the
         /// nearest ancestor for a host that is not in a navigation stack, which
         /// still keeps the override off the window.
+        ///
+        /// One exception, for the conversation presented as a sheet rather than
+        /// pushed: SwiftUI re-derives the trait overrides of a presented stack's
+        /// *root* controller from the presenting environment on every update, so
+        /// an override set there is wiped by the next re-render - and a live
+        /// transcript re-renders constantly, which left the sheet light. The
+        /// presented controller itself is not reconciled that way, so it takes
+        /// the override instead. It is still not the window: the conversations
+        /// list behind the sheet keeps its own appearance, and the override goes
+        /// away with the sheet.
+        ///
+        /// A screen *pushed* inside a sheet keeps its own override (verified on
+        /// the simulator), so it stays the styled screen and the sheet's root
+        /// below it is left alone.
         private var screenController: UIViewController? {
-            let ancestors = sequence(first: self as UIViewController) { $0.parent }
-            return ancestors.first { $0.parent is UINavigationController } ?? parent
+            let chain = ancestors
+            let presentedRoot = chain.last.flatMap { $0.presentingViewController != nil ? $0 : nil }
+            guard let pushed = chain.first(where: { $0.parent is UINavigationController }) else {
+                return presentedRoot ?? parent
+            }
+            if let presentedRoot,
+               let navigation = pushed.parent as? UINavigationController,
+               navigation.viewControllers.first === pushed {
+                return presentedRoot
+            }
+            return pushed
         }
 
         private func applyStyle() {


### PR DESCRIPTION
The Agent tab renders light when the conversation is presented as a sheet (new convo from the contacts list), which leaves outgoing message bubbles with no background against a white transcript.

## Why

The Agent tab's dark surface is a UIKit trait override, not `preferredColorScheme`: the transcript's collection view and cells, glass/material effects, and the keyboard resolve against the trait collection rather than SwiftUI's `colorScheme` environment. `ScreenAppearanceScope` (#1392) put that override on *the controller the navigation stack pushed*, so it would leave with the screen it belongs to rather than sitting on the window — which is what kept the conversations list from flashing dark for the length of the pop animation.

Presented as a sheet, that controller is the stack's **root**. SwiftUI re-derives a presented stack root's trait overrides from the presenting environment whenever its body re-renders, so the override is applied and then wiped by the next update.

That is what made this look intermittent: with nothing re-rendering, the override survives and the tab is correctly dark. It only breaks when a re-render lands after the style was set.

## Fix

In that one case — the ancestor chain's outermost controller is presented, and the pushed-screen candidate is that stack's `viewControllers.first` — style the presented controller instead. Everything else keeps the pushed-screen rule, and the override still never reaches the window.

A screen *pushed inside* a sheet (the contact card's "Convos with you" rows) keeps its own override, so it stays the styled screen and the sheet root behind it is left alone.

## Testing

Verified on the simulator. Also reproduced and fixed in a standalone SwiftUI harness (swiftc straight to a `.app`, self-driving) covering all three presentation shapes with the subtree re-rendering throughout:

| | pushed on app's stack | sheet root | pushed inside a sheet |
|---|---|---|---|
| before, no re-renders | dark | dark | dark |
| before, subtree re-rendering | dark | **light — the bug** | dark |
| after, subtree re-rendering | dark | dark | dark, sheet root stays light |

The top row is worth noting: on a static screen the old code looks correct, so a spot check does not tell you anything.

One caveat on scope of verification: the scripted flow I used on the simulator never reproduced the light sheet on the pre-fix build (10 runs, including a sweep of how soon the Agent tab is selected after Continue) — the repro was hand-driven. So the simulator evidence for the fix is manual passes, and the deterministic before/after comes from the harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `screenController` to target presented root for sheet-style conversations
> Rewrites `ScreenAppearanceScope.Controller.screenController` to walk the full ancestor chain (via a new `ancestors` property) instead of only checking the immediate parent. This targets the presented root view controller for modally presented screens, so the Agent tab stays dark when a conversation is presented as a sheet, while still targeting the pushed controller for navigation-stack screens.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7178e88.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->