### PR TITLE
chore(deps): update convos-releases flake input to 9d84268

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784988777,
-        "narHash": "sha256-dcF61u/iHQYnetqddHC6L78lELIBOaTdEB6LdY6jwEw=",
+        "lastModified": 1787597267,
+        "narHash": "sha256-VR4Mlp+sH4UYJIha/rFrMrWf7ckKEO+J0XcGKcdvI74=",
         "owner": "xmtplabs",
         "repo": "convos-releases",
-        "rev": "5cfa214ae04ddac73f483f9589a52bb46bee49bd",
+        "rev": "9d842688523b98efde913c192f1a29f08ace0a12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps the `convos-releases` flake input from `5cfa214` (2026-07-25) to `9d84268` (today).

## Why now

This repo pins the `train` CLI (and the fastlane lanes) through this input — `nix/modules/devshell.nix` pulls `inputs'.convos-releases.packages.train`, and the promote workflow runs `train promote prepare` / `train promote record` from that dev shell. So the back-merge fixes only take effect here once this lock moves:

- **convos-releases#42** — promotion no longer resurrects `release/<v>` to reuse as the back-merge PR head. That branch creation fired a real push event, which re-triggered `release-rc.yml` and uploaded TestFlight build 1368 *after* 2.5.0 had promoted with 1367 — the BUILD MISMATCH on the release dashboard.
- **convos-releases#43** — the back-merge PR head now carries version files pre-resolved to dev's version, so a back-merge can never downgrade dev (the 2.5.0 back-merge PR #1416 was a clean-merging pure `MARKETING_VERSION` downgrade that only a red version-alignment check stopped).

The workflow-level guard from #42 (refusing RC uploads once `v<version>` is tagged) is already live — the reusable-workflow callers here use `@main`.

## Scope / risk

The span is `train/` plus convos-releases' own CI and release manifests. **`fastlane/` is unchanged**, so the lanes this dev shell exports are byte-identical — build and upload behavior does not change. The only behavior change is in the `train` CLI, which runs during promotion.

Verified locally: `nix build .#devShells.<system>.default` succeeds, and the newly pinned `train` package contains the `backmerge/<v>` logic.

## Why this wasn't automatic

`renovate.json` has an enabled `convos-releases` rule, but the config extends `config:recommended`, which leaves `lockFileMaintenance` disabled — and an unpinned branch input (`github:xmtplabs/convos-releases`, no ref) has no version for Renovate to bump, so nothing was ever opened. Worth enabling `lockFileMaintenance` for the nix manager if we want these to flow automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790189647&installation_model_id=20076&pr_number=1422&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1422&signature=0e21b071ac834ad8280fed0e8011a43116e95371637e6eeba13fa1aa909c8e05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `convos-releases` flake input to commit `9d84268`
> Updates the `flake.lock` entry for the `convos-releases` input to the latest pinned commit. No other inputs or configuration are changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3676c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->