### PR TITLE
DNM: double-tap a conversation row to open the agent DM tab

### DIFF
--- a/Convos/Conversations List/ConversationsView.swift
+++ b/Convos/Conversations List/ConversationsView.swift
@@ -236,6 +236,9 @@ struct ConversationsView: View {
             onSelectConversation: { conversation in
                 viewModel.select(conversation)
             },
+            onSelectConversationAgentDm: { conversation in
+                viewModel.selectOpeningAgentDm(conversation)
+            },
             onConfirmedDeleteConversation: { conversation in
                 viewModel.leave(conversation: conversation)
             },

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -70,6 +70,20 @@ final class ConversationsViewModel {
         selectedConversationId = conversation.id
     }
 
+    /// Selects a conversation from the list and forces the pushed view onto the
+    /// agent-DM page (double-tap shortcut), independent of unread state. Falls
+    /// back to the group when the conversation has no verified agent.
+    func selectOpeningAgentDm(_ conversation: Conversation) {
+        selectedInitialAgentDmInboxId = primaryAgentInboxId(in: conversation)
+        selectedConversationId = conversation.id
+    }
+
+    /// Mirrors `ConversationView.primaryAgentInboxId` so the seeded tab matches.
+    private func primaryAgentInboxId(in conversation: Conversation) -> String? {
+        guard !conversation.isAgentDm else { return nil }
+        return conversation.members.first { $0.isVerifiedAgent }?.profile.inboxId
+    }
+
     /// Returns the agent inbox id to open the DM page for, when the DM holds the
     /// most-recent unread message; nil to open the group page.
     private func agentDmInboxIdForMostRecentUnread(in conversation: Conversation) -> String? {

--- a/Convos/Conversations List/View Controller/Cells/ConversationListItemCell.swift
+++ b/Convos/Conversations List/View Controller/Cells/ConversationListItemCell.swift
@@ -42,6 +42,14 @@ final class ConversationListItemCell: UICollectionViewListCell {
             : "conversation-list-item-\(conversation.id)"
     }
 
+    /// Holds the pressed ("down") appearance independently of the cell's
+    /// touch-driven `isHighlighted`, so the row can stay visibly pressed from
+    /// touch-down through the tap-recognizer's single/double disambiguation
+    /// window instead of clearing the instant the finger lifts.
+    func setPressedHeld(_ held: Bool) {
+        hostingWrapper?.isPressedHeld = held
+    }
+
     override func updateConfiguration(using state: UICellConfigurationState) {
         super.updateConfiguration(using: state)
         hostingWrapper?.isSwiped = state.isSwiped
@@ -69,6 +77,7 @@ final class ConversationListItemWrapper {
     var isSelected: Bool
     var isSwiped: Bool = false
     var isHighlighted: Bool = false
+    var isPressedHeld: Bool = false
     // Held on the wrapper (not injected once at build time) so a recycled cell
     // applies the latest resolver: `configure(with:)` reuses this wrapper via
     // `update(...)`, and the view controller reassigns its
@@ -104,9 +113,15 @@ struct ConversationListItemWrapperView: View {
         UIDevice.current.userInterfaceIdiom == .phone
     }
 
+    /// True while the row is pressed - either the live touch-driven highlight or
+    /// the held pressed state that spans the tap disambiguation window.
+    private var isPressedDown: Bool {
+        wrapper.isHighlighted || wrapper.isPressedHeld
+    }
+
     private var shouldHighlight: Bool {
         if isPhone {
-            return wrapper.isSwiped || wrapper.isHighlighted
+            return wrapper.isSwiped || isPressedDown
         }
         return wrapper.isSwiped || wrapper.isSelected
     }
@@ -115,7 +130,7 @@ struct ConversationListItemWrapperView: View {
         ConversationsListItem(conversation: wrapper.conversation)
             .background {
                 if shouldHighlight {
-                    if isPhone, wrapper.isHighlighted, !wrapper.isSwiped {
+                    if isPhone, isPressedDown, !wrapper.isSwiped {
                         Rectangle()
                             .fill(Color.colorFillMinimal)
                     } else {

--- a/Convos/Conversations List/View Controller/ConversationsViewController.swift
+++ b/Convos/Conversations List/View Controller/ConversationsViewController.swift
@@ -103,6 +103,8 @@ final class ConversationsViewController: UIViewController {
     // MARK: - Callbacks
 
     var onSelectConversation: ((Conversation) -> Void)?
+    /// Fired on a double tap - opens the conversation directly on the agent DM page.
+    var onSelectConversationAgentDm: ((Conversation) -> Void)?
     var onConfirmedDeleteConversation: ((Conversation) -> Void)?
     var onExplodeConversation: ((Conversation) -> Void)?
     var onToggleMute: ((Conversation) -> Void)?
@@ -241,6 +243,44 @@ final class ConversationsViewController: UIViewController {
             collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
+        setupTapRecognizers()
+    }
+
+    /// A single tap opens the conversation (smart default tab); a double tap
+    /// opens it directly on the agent DM page. Navigation is driven from these
+    /// recognizers rather than `didSelectItemAt` so the single tap can defer to
+    /// the double tap; `didSelectItemAt` is kept only for the tap-highlight.
+    private func setupTapRecognizers() {
+        let doubleTap = UITapGestureRecognizer(target: self, action: #selector(handleDoubleTap(_:)))
+        doubleTap.numberOfTapsRequired = 2
+        doubleTap.delegate = self
+        doubleTap.cancelsTouchesInView = false
+        collectionView.addGestureRecognizer(doubleTap)
+
+        let singleTap = UITapGestureRecognizer(target: self, action: #selector(handleSingleTap(_:)))
+        singleTap.numberOfTapsRequired = 1
+        singleTap.delegate = self
+        singleTap.cancelsTouchesInView = false
+        singleTap.require(toFail: doubleTap)
+        collectionView.addGestureRecognizer(singleTap)
+    }
+
+    @objc
+    private func handleSingleTap(_ recognizer: UITapGestureRecognizer) {
+        guard let conversation = conversation(atPointIn: recognizer) else { return }
+        onSelectConversation?(conversation)
+    }
+
+    @objc
+    private func handleDoubleTap(_ recognizer: UITapGestureRecognizer) {
+        guard let conversation = conversation(atPointIn: recognizer) else { return }
+        onSelectConversationAgentDm?(conversation)
+    }
+
+    private func conversation(atPointIn recognizer: UITapGestureRecognizer) -> Conversation? {
+        let location = recognizer.location(in: collectionView)
+        guard let indexPath = collectionView.indexPathForItem(at: location) else { return nil }
+        return conversation(for: indexPath)
     }
 
     private func createLayout() -> UICollectionViewLayout {
@@ -686,6 +726,17 @@ final class ConversationsViewController: UIViewController {
     }
 }
 
+// MARK: - UIGestureRecognizerDelegate
+
+extension ConversationsViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        true
+    }
+}
+
 // MARK: - UICollectionViewDelegate
 
 extension ConversationsViewController: UICollectionViewDelegate {
@@ -700,10 +751,10 @@ extension ConversationsViewController: UICollectionViewDelegate {
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        // Navigation is driven by the tap recognizers (see setupTapRecognizers)
+        // so a single tap can defer to a double tap; this only clears the
+        // momentary selection highlight.
         collectionView.deselectItem(at: indexPath, animated: true)
-
-        guard let conversation = conversation(for: indexPath) else { return }
-        onSelectConversation?(conversation)
     }
 
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {

--- a/Convos/Conversations List/View Controller/ConversationsViewController.swift
+++ b/Convos/Conversations List/View Controller/ConversationsViewController.swift
@@ -283,6 +283,36 @@ final class ConversationsViewController: UIViewController {
         return conversation(for: indexPath)
     }
 
+    /// The list row currently showing the held pressed state, and the safety
+    /// timer that clears it if no tap/scroll/menu resolves the press.
+    private weak var pressedHeldCell: ConversationListItemCell?
+    private var clearPressedHeldWorkItem: DispatchWorkItem?
+
+    /// Latches the pressed appearance on the touched row from touch-down so the
+    /// user gets immediate feedback that spans the single/double tap
+    /// disambiguation window, instead of it clearing the instant the finger
+    /// lifts. A safety timeout guards against gesture paths that never resolve
+    /// (system-cancelled touches).
+    private func holdPressedState(at indexPath: IndexPath) {
+        clearPressedState()
+        guard let cell = collectionView.cellForItem(at: indexPath) as? ConversationListItemCell else { return }
+        cell.setPressedHeld(true)
+        pressedHeldCell = cell
+
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.clearPressedState()
+        }
+        clearPressedHeldWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + Constant.pressedStateMaxHold, execute: workItem)
+    }
+
+    private func clearPressedState() {
+        clearPressedHeldWorkItem?.cancel()
+        clearPressedHeldWorkItem = nil
+        pressedHeldCell?.setPressedHeld(false)
+        pressedHeldCell = nil
+    }
+
     private func createLayout() -> UICollectionViewLayout {
         let layout = ConversationsCompositionalLayout { [weak self] sectionIndex, environment in
             guard let self = self else { return nil }
@@ -757,12 +787,21 @@ extension ConversationsViewController: UICollectionViewDelegate {
         collectionView.deselectItem(at: indexPath, animated: true)
     }
 
+    func collectionView(_ collectionView: UICollectionView, didHighlightItemAt indexPath: IndexPath) {
+        holdPressedState(at: indexPath)
+    }
+
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         guard currentState.hasMoreConversations else { return }
         guard let item = dataSource.itemIdentifier(for: indexPath), case .conversation = item else { return }
         let listCount = currentState.unpinnedConversations.count
         guard listCount > 0, indexPath.item >= listCount - Constant.loadMoreThreshold else { return }
         onLoadMoreConversations?()
+    }
+
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        // The touch became a scroll, not a tap - drop the held pressed state.
+        clearPressedState()
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
@@ -780,6 +819,10 @@ extension ConversationsViewController: UICollectionViewDelegate {
         contextMenuConfigurationForItemAt indexPath: IndexPath,
         point: CGPoint
     ) -> UIContextMenuConfiguration? {
+        // A long press opened the menu, so the touch is not a tap - drop the
+        // held pressed state rather than leaving the row latched behind it.
+        clearPressedState()
+
         guard let item = dataSource.itemIdentifier(for: indexPath),
               let conversation = conversation(for: indexPath) else {
             return nil
@@ -915,4 +958,8 @@ extension ConversationsViewController: UICollectionViewDelegate {
 private enum Constant {
     /// How many rows before the end of the list the next page is requested.
     static let loadMoreThreshold: Int = 10
+    /// Safety cap on the held pressed state, in case no tap, scroll, or menu
+    /// resolves the press (e.g. a system-cancelled touch). Longer than the tap
+    /// disambiguation window so a normal single tap is never cut short.
+    static let pressedStateMaxHold: TimeInterval = 0.7
 }

--- a/Convos/Conversations List/View Controller/ConversationsViewRepresentable.swift
+++ b/Convos/Conversations List/View Controller/ConversationsViewRepresentable.swift
@@ -19,6 +19,7 @@ struct ConversationsViewRepresentable: UIViewControllerRepresentable {
 
     // Callbacks
     var onSelectConversation: ((Conversation) -> Void)?
+    var onSelectConversationAgentDm: ((Conversation) -> Void)?
     var onConfirmedDeleteConversation: ((Conversation) -> Void)?
     var onExplodeConversation: ((Conversation) -> Void)?
     var onToggleMute: ((Conversation) -> Void)?
@@ -59,6 +60,7 @@ struct ConversationsViewRepresentable: UIViewControllerRepresentable {
 
     private func configureCallbacks(_ viewController: ConversationsViewController) {
         viewController.onSelectConversation = onSelectConversation
+        viewController.onSelectConversationAgentDm = onSelectConversationAgentDm
         viewController.onConfirmedDeleteConversation = onConfirmedDeleteConversation
         viewController.onExplodeConversation = onExplodeConversation
         viewController.onToggleMute = onToggleMute


### PR DESCRIPTION
## What

Double-tapping a conversation row in the conversation list opens the conversation directly on the **Agent** DM tab. A single tap keeps its existing smart-default behavior (opens the Agent tab when the newest unread lives in the DM, otherwise Group).

## How

- `ConversationsViewModel.selectOpeningAgentDm(_:)` forces the Agent tab by setting `selectedInitialAgentDmInboxId` to the conversation's primary verified-agent inbox id (mirrors `ConversationView.primaryAgentInboxId`). Falls back to Group when there's no verified agent.
- `ConversationsViewController` now drives navigation from single/double `UITapGestureRecognizer`s instead of `didSelectItemAt` (which only clears the tap highlight now), with `singleTap.require(toFail: doubleTap)`. Recognizers use `cancelsTouchesInView = false` and simultaneous recognition so swipe actions, the context-menu long-press, cell content, and scrolling all keep working.
- Callback threaded through `ConversationsViewRepresentable` and wired in `ConversationsView`.

## Notes / tradeoffs

- **DNM** while we settle the gesture. The single-tap open now waits UIKit's default inter-tap timeout (~0.3s) on every row to disambiguate the double tap. We discussed alternatives (spatial tap on the agent avatar, full-swipe, context-menu item) that avoid the delay — this PR ships the straightforward double-tap for now.
- Applies to both pinned and unpinned rows; double-tapping a group with no agent opens on Group.

## Testing

- Builds clean (Convos (Dev)); lint clean; installed + launched in the simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790233691&installation_model_id=20076&pr_number=1424&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1424&signature=5f2377a5bcd9166c34bc2e990b0ed38c16456cf563419be61382111169cb161b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add double-tap gesture to `ConversationsViewController` to open agent DM tab
> - Replaces `didSelectItemAt:` navigation with explicit single- and double-tap gesture recognizers in [ConversationsViewController.swift](https://github.com/xmtplabs/convos-ios/pull/1424/files#diff-477804c80e87d96b804888bf7f0b51b37477226561d8f5253245aa4f24631871). Single-tap opens the conversation normally, while double-tap calls `selectOpeningAgentDm` to open the verified agent DM tab.
> - Adds `setPressedHeld(_:)` to `ConversationListItemCell` and a latching mechanism in the view controller so rows stay visually pressed during tap disambiguation. The state clears on scroll, context menu invocation, or a 0.7s timeout (`Constant.pressedStateMaxHold`).
> - Behavioral Change: `ConversationsViewController.collectionView(_:didSelectItemAt:)` now only deselects items; navigation occurs entirely via the new gesture recognizers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52efc0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->