### PR TITLE
fix(agent): make "Add an agent" work on conversations that have people in them

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -4399,12 +4399,6 @@ extension ConversationViewModel {
         }
     }
 
-    /// Bare-join convenience for the in-conversation "add an agent"
-    /// affordances. Kept so their call sites don't change.
-    func requestAgentJoin() {
-        requestAgentJoin(templateId: nil)
-    }
-
     /// Sequential batched variant of `requestAgentJoin(templateId:)`. Used
     /// when the picker confirmed multiple agent templates at once. Awaits
     /// each call to completion before firing the next, with a short

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager+DefaultConversationAgent.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager+DefaultConversationAgent.swift
@@ -118,11 +118,11 @@ extension SessionManager {
         }
     }
 
-    /// Ensures the conversation has its default agent: no-op when the
-    /// conversation already has a second member, otherwise provisions a bare
-    /// agent (join with no template, greeting deferred) and adds it. Safe to
-    /// call repeatedly - concurrent callers share one provision task, and a
-    /// failed provision is retryable on the next call.
+    /// Ensures the conversation has its default agent: no-op when an agent is
+    /// already in it, otherwise provisions a bare agent (join with no
+    /// template, greeting deferred) and adds it. Safe to call repeatedly -
+    /// concurrent callers share one provision task, and a failed provision is
+    /// retryable on the next call.
     func ensureDefaultAgentInConversation(id conversationId: String) async {
         guard Self.defaultAgentProvisioningEnabled(environment) else { return }
         let task = await defaultAgentCoordinator.provisionTask(for: conversationId) { [weak self] in
@@ -147,8 +147,12 @@ extension SessionManager {
 
     private func runDefaultAgentProvision(conversationId: String) async {
         do {
-            guard try await conversationLacksSecondMember(conversationId) else {
-                Log.debug("Default agent: conversation \(conversationId) already has a second member, skipping provision")
+            guard try await conversationLacksAgent(conversationId) else {
+                Log.debug("Default agent: conversation \(conversationId) already has an agent, skipping provision")
+                // Nothing is in flight, so nothing should read as in flight.
+                // Leaving the task cached is what pinned the Agent tab in its
+                // "preparing" state until the app relaunched.
+                await defaultAgentCoordinator.clearProvisionTask(for: conversationId)
                 return
             }
             let variantId = await Self.defaultAgentVariantIdProvider?(conversationId)
@@ -229,14 +233,38 @@ extension SessionManager {
         }
     }
 
-    /// Cache-prepared conversations start with the creator as sole member, so
-    /// a second member row means the default agent (or someone else) is
-    /// already in.
-    private func conversationLacksSecondMember(_ conversationId: String) async throws -> Bool {
+    /// Whether the conversation still needs a default agent: nobody in it is
+    /// an agent, and nobody in it ever verified as one.
+    ///
+    /// Deliberately not "lacks a second member". Cache-prepared conversations
+    /// start with the creator as sole member, so a bare member count answered
+    /// this question for the provisioner's first caller - but it reads as "an
+    /// agent is already here" for any conversation that has people in it,
+    /// which silently dropped every user-initiated "Add an agent" tap (a
+    /// conversation created before agents joined by default, or whose silent
+    /// provision never landed - the two cases this path exists to serve).
+    ///
+    /// `hasHadVerifiedAgent` is the sticky historical answer; the member join
+    /// is the live one, and settles first because it needs no key-package
+    /// verification. Every `DBMemberKind` is an agent kind, so a member whose
+    /// profile carries one is an agent. The current user has no `profile` row
+    /// (self identity lives in `myProfile`), so the creator never matches.
+    /// Internal rather than private so the unit suite can pin its semantics.
+    func conversationLacksAgent(_ conversationId: String) async throws -> Bool {
         try await databaseReader.read { db in
-            try DBConversationMember
+            let hasHadVerifiedAgent = try DBConversation
+                .filter(DBConversation.Columns.id == conversationId)
+                .fetchOne(db)?
+                .hasHadVerifiedAgent ?? false
+            guard !hasHadVerifiedAgent else { return false }
+            let agentMemberCount = try DBConversationMember
                 .filter(DBConversationMember.Columns.conversationId == conversationId)
-                .fetchCount(db) <= 1
+                .joining(
+                    required: DBConversationMember.profile
+                        .filter(DBProfile.Columns.memberKind != nil)
+                )
+                .fetchCount(db)
+            return agentMemberCount == 0
         }
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/DefaultAgentProvisionGuardTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DefaultAgentProvisionGuardTests.swift
@@ -1,0 +1,183 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Coverage for the predicate that decides whether the default-agent
+/// provisioner runs. It used to ask "does this conversation lack a second
+/// member?", which is only equivalent to "does it lack an agent?" for the
+/// warm-cache conversation it was written against — the creator alone in a
+/// fresh row. For any conversation that has people in it the old question
+/// answered "an agent is already here", so the user-initiated "Add an agent"
+/// tap provisioned nothing. These pin the question it asks now.
+@Suite("Default agent provision guard")
+struct DefaultAgentProvisionGuardTests {
+    private static let currentInboxId: String = "inbox-current"
+    private static let humanInboxId: String = "inbox-human"
+    private static let agentInboxId: String = "inbox-agent"
+
+    @Test("A conversation with only the creator still needs an agent")
+    func creatorAloneLacksAgent() async throws {
+        let session = try makeSession { db in
+            try Self.seedConversation(db: db, id: "c1", memberInboxIds: [Self.currentInboxId])
+        }
+
+        #expect(try await session.conversationLacksAgent("c1") == true)
+    }
+
+    /// The regression. A group with other people but no agent must still
+    /// provision — this is the case the old member-count guard dropped.
+    @Test("A conversation with human members but no agent still needs one")
+    func humanMembersStillLackAgent() async throws {
+        let session = try makeSession { db in
+            try Self.seedHuman(db: db, inboxId: Self.humanInboxId)
+            try Self.seedConversation(
+                db: db,
+                id: "c2",
+                memberInboxIds: [Self.currentInboxId, Self.humanInboxId]
+            )
+        }
+
+        #expect(try await session.conversationLacksAgent("c2") == true)
+    }
+
+    @Test("A conversation with an agent member does not need another")
+    func agentMemberIsDetected() async throws {
+        let session = try makeSession { db in
+            try Self.seedAgent(db: db, inboxId: Self.agentInboxId, kind: .verifiedConvos)
+            try Self.seedConversation(
+                db: db,
+                id: "c3",
+                memberInboxIds: [Self.currentInboxId, Self.agentInboxId]
+            )
+        }
+
+        #expect(try await session.conversationLacksAgent("c3") == false)
+    }
+
+    /// An agent that has joined but not yet verified is still an agent. This
+    /// is why the predicate reads member kind and not `hasHadVerifiedAgent`
+    /// alone — verification lands later, and a second provision in that
+    /// window would seat a duplicate.
+    @Test("An unverified agent member counts as an agent")
+    func unverifiedAgentMemberIsDetected() async throws {
+        let session = try makeSession { db in
+            try Self.seedAgent(db: db, inboxId: Self.agentInboxId, kind: .agent)
+            try Self.seedConversation(
+                db: db,
+                id: "c4",
+                memberInboxIds: [Self.currentInboxId, Self.agentInboxId]
+            )
+        }
+
+        #expect(try await session.conversationLacksAgent("c4") == false)
+    }
+
+    /// The sticky historical answer, for a conversation whose agent has since
+    /// left or whose profile row hasn't synced.
+    @Test("hasHadVerifiedAgent alone is enough to skip")
+    func stickyVerifiedFlagSkips() async throws {
+        let session = try makeSession { db in
+            try Self.seedConversation(
+                db: db,
+                id: "c5",
+                memberInboxIds: [Self.currentInboxId],
+                hasHadVerifiedAgent: true
+            )
+        }
+
+        #expect(try await session.conversationLacksAgent("c5") == false)
+    }
+
+    // MARK: - Helpers
+
+    private func makeSession(seed: (Database) throws -> Void) throws -> SessionManager {
+        let databaseManager = MockDatabaseManager.makeTestDatabase()
+        try databaseManager.dbWriter.write { db in
+            try Self.seedInbox(db: db)
+            try seed(db)
+        }
+        return SessionManager(
+            databaseWriter: databaseManager.dbWriter,
+            databaseReader: databaseManager.dbReader,
+            environment: .tests,
+            identityStore: MockKeychainIdentityStore(),
+            platformProviders: .mock
+        )
+    }
+
+    private static func seedInbox(db: Database) throws {
+        try DBMember(inboxId: currentInboxId).save(db, onConflict: .ignore)
+        try DBInbox(
+            inboxId: currentInboxId,
+            clientId: "client-current",
+            createdAt: Date()
+        ).save(db, onConflict: .ignore)
+    }
+
+    /// A human member: a `profile` row with no `memberKind`.
+    private static func seedHuman(db: Database, inboxId: String) throws {
+        try DBMember(inboxId: inboxId).save(db, onConflict: .ignore)
+        try DBProfile(
+            inboxId: inboxId,
+            name: "Human",
+            memberKind: nil,
+            profileSource: .profileUpdate,
+            updatedAt: Date()
+        ).save(db)
+    }
+
+    private static func seedAgent(db: Database, inboxId: String, kind: DBMemberKind) throws {
+        try DBMember(inboxId: inboxId).save(db, onConflict: .ignore)
+        try DBProfile(
+            inboxId: inboxId,
+            name: "Agent",
+            memberKind: kind,
+            profileSource: .profileUpdate,
+            updatedAt: Date()
+        ).save(db)
+    }
+
+    private static func seedConversation(
+        db: Database,
+        id: String,
+        memberInboxIds: [String],
+        hasHadVerifiedAgent: Bool = false
+    ) throws {
+        try DBConversation(
+            id: id,
+            clientConversationId: "client-\(id)",
+            inviteTag: "tag-\(id)",
+            creatorId: currentInboxId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(),
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: hasHadVerifiedAgent
+        ).insert(db)
+
+        for (index, inboxId) in memberInboxIds.enumerated() {
+            try DBConversationMember(
+                conversationId: id,
+                inboxId: inboxId,
+                role: index == 0 ? .superAdmin : .member,
+                consent: .allowed,
+                createdAt: Date(),
+                invitedByInboxId: nil
+            ).insert(db)
+        }
+    }
+}


### PR DESCRIPTION
## The bug

Tapping **Add an agent** does nothing on any conversation that already has people in it — which is every pre-existing conversation. No `agents/join` call is ever made; the tap is a no-op by construction, not a hit-testing or network problem.

Both affordances — the Agent tab (`AgentDmPageView`) and the Things tab's Space surface (`ConversationView`) — route to `AgentDmSession.requestAgentJoin()`, which deliberately goes through the session's silent default-agent provisioner so it shares any in-flight provision and its idempotency key. The first statement in `runDefaultAgentProvision` was:

```swift
guard try await conversationLacksSecondMember(conversationId) else {
    Log.debug("… already has a second member, skipping provision")
    return
}
```

and `conversationLacksSecondMember` was a raw member-row count `<= 1`. That count includes the current user, so "≤ 1" means *nobody but me*. It is a correct proxy for "the default agent hasn't landed yet" only on the path it was written for — a warm-cache conversation with the creator as its sole member. On the user-initiated path, the only path that runs against a populated conversation, it always reads as "an agent is already here" and returns.

The method's own doc comment states the intent it couldn't deliver: *"for a conversation that has none (one created before agents joined by default, or whose silent provision never landed)."*

### It also wedges the tab

`clearProvisionTask` ran only in the `catch` branch, and a skip is a success — so the skipped task stayed cached in `DefaultConversationAgentCoordinator.provisionTasks`. `isProvisioningDefaultAgent` then answered `true` forever, and the next `refreshDefaultAgentProvisioning()` (every tab switch) pinned the conversation in **"Preparing your agent chat"** for the rest of the app session. Relaunching is what brought the button back.

## The fix

Ask whether the conversation lacks an **agent**, not a second member:

- no member whose `profile` carries a `memberKind` — every `DBMemberKind` case is an agent kind, and the current user has no `profile` row (self identity lives in `myProfile`), so the creator never matches;
- and not the sticky `hasHadVerifiedAgent`.

The member join settles *before* key-package verification, so an agent that has joined but not yet verified still blocks a duplicate provision — which is why this reads member kind rather than `hasHadVerifiedAgent` alone.

Plus: clear the provision task on the skip path, so a no-op provision stops masquerading as one in flight.

## Blast radius

Loosening the guard cannot start adding agents to groups you merely *joined*. Every caller other than the button is scoped to a conversation the user created:

| Caller | Scope |
| --- | --- |
| `AgentDmSession.requestAgentJoin` | the explicit tap |
| `NewConversationViewModel` | guarded by `result.origin == .created` |
| `SessionManager` claim-time backstop | the conversation just claimed from the cache |
| `commitClaimedConversation` | the conversation just committed |
| `wireDefaultAgentProvisioner` | warm-cache row, creator-only |

So the newly-unblocked cases are exactly the two the path documents.

## Testing

New `DefaultAgentProvisionGuardTests` (5 tests) pins the predicate's semantics: creator-alone, human-members-but-no-agent, agent member, *unverified* agent member, and the sticky flag.

Verified the tests actually catch this bug — reverted the predicate to the old member-count logic and re-ran:

```
✘ "A conversation with human members but no agent still needs one" — Expectation failed
✘ "hasHadVerifiedAgent alone is enough to skip" — Expectation failed
Test run with 5 tests … failed with 2 issues
```

With the fix in place:

```
Test run with 5 tests in 1 suite passed after 0.366 seconds.
```

Full ConvosCore unit target: **1948 tests in 246 suites passed**. SwiftLint clean on all changed files. The `Convos (Dev)` app target builds clean for the simulator (`** BUILD SUCCEEDED **`, 0 errors) — needed for the dead-code commit, since `ConversationViewModel` is in the app target and `swift test` never compiles it.

Not exercised on a device from here. To confirm on-device, attach Console and tap the button on an existing group — you should now see `Default agent: provisioned into conversation <id>` where the old build logged `already has a second member, skipping provision`.

## Dead code removed

`ConversationViewModel.requestAgentJoin()` (the no-arg overload) forwarded to `requestAgentJoin(templateId: nil)` and described itself as *"Bare-join convenience for the in-conversation 'add an agent' affordances. Kept so their call sites don't change."* Those affordances were rerouted to `AgentDmSession.requestAgentJoin()`, so it has had zero call sites and the comment has been stale ever since. Removed in its own commit.

The `requestAgentJoin(templateId:requestId:)` it wrapped is untouched and still live from the chat "+" menu and the retry path. I swept the rest of the agent-join surface — `retryAgentJoin`, `runSequentialAgentJoins`, `requestAgentJoins`, `AddAgentPromptView`, `isAgentJoinPending`, `refreshDefaultAgentProvisioning`, `failedAgentJoins`, `agentJoinTaskId` — and all still have live call sites, so that was the only orphan.

## Not touched: the Home bridge

`HomeChatPlugin.requestAgentJoin()` sets `AgentStatus(state: .JOINING)` and never provisions, so the Home/Space web bridge cannot add an agent either. It is **not** dead code: it conforms to `ChatPlugin` from `ConvosBridge`, and `HomeBridgeHost` documents the placeholder as deliberate — *"Agent status is a local placeholder matching the Android stubs: real wiring to the conversation view model is a follow-up."*

Wiring it would mean adding a `requestAgentJoin` closure to `HomeBridgeNavigation` fed from the conversation-scoped web view, the way `showMembersList` is. That is a feature change on a surface this PR does not otherwise touch, so it is left for the tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix default agent provisioning to work on conversations with human members
> Replaces the member-count-based guard `conversationLacksSecondMember` with `conversationLacksAgent`, which checks for actual agent presence (non-nil `memberKind`) and the `DBConversation.hasHadVerifiedAgent` flag. This allows conversations with human members but no agent to correctly trigger default-agent provisioning, while skipping when an agent is already present or was previously verified.
>
> - Adds `defaultAgentCoordinator.clearProvisionTask(for:)` call in `runDefaultAgentProvision` when the guard detects an existing agent, so no stale provision task lingers
> - Removes the no-argument `ConversationViewModel.requestAgentJoin` convenience overload; call sites must use an overload that supplies arguments
> - Adds `DefaultAgentProvisionGuardTests` with five cases covering creator-only, human-only, verified-agent, unverified-agent, and `hasHadVerifiedAgent` scenarios
> - Behavioral Change: `SessionManager.conversationLacksAgent` is now `internal` (was `private`) to support unit tests; conversations with human members that previously skipped provisioning will now provision a default agent
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a371eba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->