### PR TITLE
chore(participation): retire the Listen feature flag

### DIFF
--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -65,33 +65,6 @@ final class FeatureFlags {
         }
     }
 
-    /// Gates the per-conversation agent participation control ("Listen"):
-    /// Speak freely / Listen mode / Paused. Toggle from App Settings -> Debug
-    /// in non-production builds, or from the curated prod debug menu in
-    /// production. Deliberately not prod-locked like the flags above: the
-    /// control is reachable everywhere so Listen can be dogfooded in TestFlight.
-    ///
-    /// On by default in every build, production included, so the control is
-    /// there without anyone having to find a debug menu first. An explicit
-    /// toggle in either direction is remembered and wins over the default, so
-    /// turning it off from the prod debug menu still sticks.
-    var isListenParticipationEnabled: Bool {
-        get {
-            access(keyPath: \.isListenParticipationEnabled)
-            guard let stored = UserDefaults.standard.object(forKey: Constant.listenParticipationEnabledKey) as? Bool else {
-                return Self.listenParticipationDefault
-            }
-            return stored
-        }
-        set {
-            withMutation(keyPath: \.isListenParticipationEnabled) {
-                UserDefaults.standard.set(newValue, forKey: Constant.listenParticipationEnabledKey)
-            }
-        }
-    }
-
-    private static let listenParticipationDefault: Bool = true
-
     /// Off by default -- opts libxmtp streams onto the shared bidi wire by
     /// exporting `XMTP_BIDI_STREAMS_ENABLED` at launch (see `ConvosApp.init`;
     /// flips take effect on the next launch). Deliberately not prod-locked
@@ -118,7 +91,7 @@ final class FeatureFlags {
     /// non-production builds, or from the curated prod debug menu in
     /// production. Deliberately not prod-locked like most flags above: the
     /// control is reachable everywhere so V2 can be dogfooded in production,
-    /// same posture as `isListenParticipationEnabled`. Default stays off in
+    /// same posture as `isXMTPBidiStreamsEnabled`. Default stays off in
     /// every environment -- enabling it in production points the client at
     /// whatever the production abilities backend currently serves, which may
     /// lag what dev has.
@@ -262,7 +235,6 @@ final class FeatureFlags {
         static let mockCreditsPresetKey: String = "featureFlags.mockCreditsPreset"
         static let selectedAgentVariantKey: String = "featureFlags.selectedAgentVariant"
         static let agentVariantSelectorEnabledKey: String = "featureFlags.agentVariantSelectorEnabled"
-        static let listenParticipationEnabledKey: String = "featureFlags.listenParticipationEnabled"
         static let xmtpBidiStreamsEnabledKey: String = "featureFlags.xmtpBidiStreamsEnabled"
         static let abilitiesV2EnabledKey: String = "featureFlags.abilitiesV2Enabled"
         static let spaceShareEnabledKey: String = "featureFlags.spaceShareEnabled"

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -62,7 +62,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
     @State private var showingLockedInfo: Bool = false
     @State private var showingFullInfo: Bool = false
     @State private var showingAgentsInfo: Bool = false
-    /// Agent participation for this conversation, behind the Listen debug flag.
+    /// Agent participation for this conversation.
     /// It lives here rather than in the composer because the level belongs to
     /// the conversation; the composer only draws the control.
     @State private var participation: AgentParticipationStore?
@@ -2029,8 +2029,7 @@ private extension ConversationView {
     /// conversation already carries. Skipped where the control would be
     /// meaningless, so a conversation without agents never draws it.
     func prepareParticipation() async {
-        guard FeatureFlags.shared.isListenParticipationEnabled,
-              viewModel.conversation.members.contains(where: \.isAgent) else {
+        guard viewModel.conversation.members.contains(where: \.isAgent) else {
             participation = nil
             return
         }

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -79,7 +79,6 @@ struct DebugViewSection: View {
         Section("Features") {
             Toggle("Debug injector button", isOn: Bindable(FeatureFlags.shared).isDebugInjectorEnabled)
             agentVariantToggles
-            Toggle("Listen (agent participation)", isOn: Bindable(FeatureFlags.shared).isListenParticipationEnabled)
             Toggle("XMTP bidi streaming (applies next launch)", isOn: Bindable(FeatureFlags.shared).isXMTPBidiStreamsEnabled)
             Toggle("Share Space (copy import link)", isOn: Bindable(FeatureFlags.shared).isSpaceShareEnabled)
             Toggle("Web inspector (space/browser web views)", isOn: Bindable(FeatureFlags.shared).isWebInspectorEnabled)

--- a/Convos/Debug View/ProdDebugMenuView.swift
+++ b/Convos/Debug View/ProdDebugMenuView.swift
@@ -20,14 +20,11 @@ import UserNotifications
 //
 // Hard rules enforced here:
 // - No mutating controls (no "Request Now", no "Register Device Again", no
-//   purchase / change-plan CTAs, no mock-credit toggles). Four deliberate
+//   purchase / change-plan CTAs, no mock-credit toggles). Three deliberate
 //   exceptions, each flipping only a local default so a tester can opt this
 //   install into a feature we are dogfooding in production:
 //   - the XMTP bidi streaming opt-in, which selects the stream transport at
 //     next launch -- nothing account- or network-mutating.
-//   - the Listen opt-in, which only decides whether the participation control
-//     is built. Turning it on mutates nothing by itself; the writes happen
-//     later, in the control, when a member actually picks a level.
 //   - the Abilities v2 opt-in, which swaps the abilities catalog list and
 //     per-conversation section from the V1 connections UI to the V2 one and
 //     points them at the live abilities backend. Off by default; nothing
@@ -184,7 +181,6 @@ struct ProdDebugMenuView: View {
             labeledRow("Debug injector", injectorEnabled ? "On" : "Off")
             // The interactive controls in this curated menu; see the
             // module overview for why they are allowed here.
-            Toggle("Listen (agent participation)", isOn: Bindable(FeatureFlags.shared).isListenParticipationEnabled)
             Toggle("XMTP bidi streaming (applies next launch)", isOn: Bindable(FeatureFlags.shared).isXMTPBidiStreamsEnabled)
             Toggle("Abilities v2", isOn: Bindable(FeatureFlags.shared).isAbilitiesV2Enabled)
             Toggle("Enable Relay (BYOA)", isOn: Bindable(FeatureFlags.shared).agentRelayEnabled)


### PR DESCRIPTION
Listen has shipped on by default in every build, production included, since #1293. The flag no longer decides anything a member sees — it only let an install opt *out*. The control is the product now, not an experiment, so it is built whenever the conversation has an agent.

## What

- **`FeatureFlags`** — removes `isListenParticipationEnabled`, its `listenParticipationDefault`, and the `Constant` key. The abilities-v2 flag's doc comment cited Listen as the precedent for "not prod-locked", so it now cites `isXMTPBidiStreamsEnabled` instead.
- **`ConversationView.prepareParticipation`** — the flag leaves the guard, which keeps its real condition: a conversation without agents still never draws the control.
- **Both debug toggles** — App Settings → Debug and the curated prod menu.

## Notes for review

- **An install that had explicitly toggled Listen off gets the control back.** That is the point of un-gating rather than an oversight, but it is a real behavior change for those testers, not a no-op. The orphaned `featureFlags.listenParticipationEnabled` default is inert and read by nothing, so it ages out rather than carrying a migration for it.
- **The prod menu's header comment was already stale.** It claimed "Four deliberate exceptions" and named bidi / Listen / Abilities v2 / Web inspector, while the section also renders Relay (BYOA) and Share Space toggles that were never in that list. This drops the Listen bullet and corrects the count; the Relay / Share Space omission predates this change and is left alone.

## Verification

`xcodebuild` `Convos (Dev)` / `Dev` — BUILD SUCCEEDED; SwiftLint clean; no remaining references to the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790268768&installation_model_id=20076&pr_number=1426&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1426&signature=0498081dacef83e7c1c69a994c1db40019ecb07d0ae641f43b12a1ffffdbed29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove the `isListenParticipationEnabled` feature flag and always enable agent participation
> - Deletes the `isListenParticipationEnabled` computed property, its default constant, and the `listenParticipationEnabledKey` entry from [FeatureFlags.swift](https://github.com/xmtplabs/convos-ios/pull/1426/files#diff-9e8aa9971f330243a3592cb6d2c4793ba683385e20db0ff00777e56f02272f7c)
> - Drops the flag guard in `ConversationView.prepareParticipation`, so `AgentParticipationStore` initializes whenever the conversation has at least one agent member
> - Removes the Listen toggle from both [DebugView.swift](https://github.com/xmtplabs/convos-ios/pull/1426/files#diff-c45ca903f9cc34fa316deb294404f56695ab7914c8a43563ade3081b646368aa) and [ProdDebugMenuView.swift](https://github.com/xmtplabs/convos-ios/pull/1426/files#diff-815af3105d8d852a87268252db30020c7003096279ca94a9c908613d1bb26cef)
> - Behavioral Change: agent participation is now always enabled in agent conversations — there is no longer a debug flag to turn it off
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e797aa9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->