### PR TITLE
fix(profile): dismiss the member profile card after removing them

### DIFF
--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -201,7 +201,7 @@ struct ContactDetailView: View {
                 "Remove \(contact.resolvedDisplayName)?",
                 isPresented: $presentingRemoveConfirmation
             ) {
-                Button("Remove", role: .destructive) { onRemove?() }
+                Button("Remove", role: .destructive) { handleRemoveConfirmed() }
                 Button("Cancel", role: .cancel) {}
             } message: {
                 Text(
@@ -638,6 +638,18 @@ struct ContactDetailView: View {
     private func handleRemoveTap() {
         // Removing the agent is destructive, so confirm natively before firing.
         presentingRemoveConfirmation = true
+    }
+
+    /// Confirming the removal always closes this card - the profile it shows
+    /// describes someone who is no longer in the conversation, so leaving it up
+    /// strands the user on a stale view. Owned here rather than by the callers
+    /// because every entry point routes through this same confirmation, and
+    /// `dismiss` resolves correctly for both presentation styles: it pops the
+    /// card pushed from the members list, and closes the sheet opened by a
+    /// member tap in a chat (same action the X button already uses).
+    private func handleRemoveConfirmed() {
+        onRemove?()
+        dismiss()
     }
 
     private func applyBlockChange(block: Bool) {

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -71,7 +71,7 @@ struct ContactDetailView: View {
     private let session: (any SessionManagerProtocol)?
     private let coreActions: any CoreActions
     private let profileSettingsViewModel: ProfileSettingsViewModel
-    private let onRemove: (() -> Void)?
+    private let onRemove: (() async throws -> Void)?
     /// When set (member sheets presented from a conversation), Chat on a
     /// DM-able agent hands the agent inboxId back to the presenter, which
     /// dismisses this sheet and selects the conversation's agent-DM page.
@@ -83,6 +83,9 @@ struct ContactDetailView: View {
     @State private var isApplyingBlockChange: Bool = false
     @State private var presentingBlockConfirmation: Bool = false
     @State private var presentingRemoveConfirmation: Bool = false
+    @State private var isRemovingMember: Bool = false
+    @State private var presentingRemoveError: Bool = false
+    @State private var removeErrorMessage: String?
     @State private var presentingPicker: Bool = false
     @State private var presentingSendMessageError: Bool = false
     @State private var sendMessageErrorMessage: String?
@@ -126,7 +129,7 @@ struct ContactDetailView: View {
         profileSettingsViewModel: ProfileSettingsViewModel = .shared,
         showsCloseButton: Bool = true,
         pushedConversationInsetsTopSafeArea: Bool = false,
-        onRemove: (() -> Void)? = nil,
+        onRemove: (() async throws -> Void)? = nil,
         onStartAgentDm: ((String) -> Void)? = nil
     ) {
         self.contact = contact
@@ -178,6 +181,9 @@ struct ContactDetailView: View {
                 presentingPicker: $presentingPicker,
                 presentingSendMessageError: $presentingSendMessageError,
                 sendMessageErrorMessage: sendMessageErrorMessage,
+                presentingRemoveError: $presentingRemoveError,
+                removeErrorTitle: removeErrorTitle,
+                removeErrorMessage: removeErrorMessage,
                 blockAlertTitle: blockAlertTitle,
                 blockAlertMessage: blockAlertMessage,
                 presentingAgentInfo: $presentingAgentInfo,
@@ -361,6 +367,7 @@ struct ContactDetailView: View {
                 ContactDetailActions(
                     isBlocked: isBlocked,
                     isApplyingBlockChange: isApplyingBlockChange,
+                    isRemovingMember: isRemovingMember,
                     // A template-backed agent's Chat spawns a fresh instance
                     // into a new conversation (see `handleChatWithAgentTemplate`).
                     // A non-template verified agent gets a private DM with the
@@ -471,6 +478,10 @@ struct ContactDetailView: View {
             suggestedAgentsService: SuggestedAgentsService.live(),
             onConfirm: handlePickerConfirm
         )
+    }
+
+    private var removeErrorTitle: String {
+        "Couldn't remove \(contact.resolvedDisplayName)"
     }
 
     // MARK: - Block alert content
@@ -640,16 +651,30 @@ struct ContactDetailView: View {
         presentingRemoveConfirmation = true
     }
 
-    /// Confirming the removal always closes this card - the profile it shows
+    /// A confirmed removal closes this card once it lands - the profile then
     /// describes someone who is no longer in the conversation, so leaving it up
     /// strands the user on a stale view. Owned here rather than by the callers
     /// because every entry point routes through this same confirmation, and
     /// `dismiss` resolves correctly for both presentation styles: it pops the
     /// card pushed from the members list, and closes the sheet opened by a
     /// member tap in a chat (same action the X button already uses).
+    ///
+    /// The dismissal waits on the removal instead of racing it. Closing
+    /// optimistically would report success for a removal that failed, leaving
+    /// the member in the conversation with nothing on screen to say so.
     private func handleRemoveConfirmed() {
-        onRemove?()
-        dismiss()
+        guard !isRemovingMember else { return }
+        isRemovingMember = true
+        Task { @MainActor in
+            defer { isRemovingMember = false }
+            do {
+                try await onRemove?()
+                dismiss()
+            } catch {
+                removeErrorMessage = error.localizedDescription
+                presentingRemoveError = true
+            }
+        }
     }
 
     private func applyBlockChange(block: Bool) {
@@ -857,6 +882,10 @@ private struct ContactDetailSubtitle: View {
 private struct ContactDetailActions: View {
     let isBlocked: Bool
     let isApplyingBlockChange: Bool
+    /// Disables the Remove row while the removal is in flight, so a second tap
+    /// can't fire another one before the card closes. Mirrors
+    /// `isApplyingBlockChange` on the Block row.
+    let isRemovingMember: Bool
     let canSendMessage: Bool
     let showChat: Bool
     /// Shows the model dropdown under Chat. Agents only - a human contact
@@ -979,7 +1008,7 @@ private struct ContactDetailActions: View {
             label: "Remove",
             footer: "Remove from convo",
             color: .colorTextPrimary,
-            isDisabled: false,
+            isDisabled: isRemovingMember,
             accessibilityLabel: "Remove \(contactDisplayName)",
             accessibilityIdentifier: "remove-member-button",
             action: onRemove
@@ -1391,6 +1420,9 @@ private struct ContactDetailModalsModifier<
     @Binding var presentingPicker: Bool
     @Binding var presentingSendMessageError: Bool
     let sendMessageErrorMessage: String?
+    @Binding var presentingRemoveError: Bool
+    let removeErrorTitle: String
+    let removeErrorMessage: String?
     let blockAlertTitle: String
     let blockAlertMessage: String
     @Binding var presentingAgentInfo: Bool
@@ -1410,6 +1442,15 @@ private struct ContactDetailModalsModifier<
                 "Couldn't open message picker",
                 isPresented: $presentingSendMessageError,
                 presenting: sendMessageErrorMessage
+            ) { _ in
+                Button("OK", role: .cancel) {}
+            } message: { message in
+                Text(message)
+            }
+            .alert(
+                removeErrorTitle,
+                isPresented: $presentingRemoveError,
+                presenting: removeErrorMessage
             ) { _ in
                 Button("OK", role: .cancel) {}
             } message: { message in

--- a/Convos/Conversation Detail/ConversationMemberView.swift
+++ b/Convos/Conversation Detail/ConversationMemberView.swift
@@ -173,9 +173,15 @@ struct ConversationMemberView: View {
 
         if viewModel.canRemoveMembers {
             Section {
-                let action = {
-                    viewModel.remove(member: member)
-                    dismiss()
+                let action: () -> Void = {
+                    Task {
+                        do {
+                            try await viewModel.remove(member: member)
+                            dismiss()
+                        } catch {
+                            Log.error("Error removing member: \(error.localizedDescription)")
+                        }
+                    }
                 }
                 Button(action: action) {
                     Text("Remove")
@@ -216,9 +222,15 @@ struct ConversationMemberView: View {
         if !member.isCurrentUser {
             if viewModel.canRemoveMembers {
                 Section {
-                    let action = {
-                        viewModel.remove(member: member)
-                        dismiss()
+                    let action: () -> Void = {
+                        Task {
+                            do {
+                                try await viewModel.remove(member: member)
+                                dismiss()
+                            } catch {
+                                Log.error("Error removing member: \(error.localizedDescription)")
+                            }
+                        }
                     }
                     Button(action: action) {
                         Text("Remove")

--- a/Convos/Conversation Detail/ConversationMembersListView.swift
+++ b/Convos/Conversation Detail/ConversationMembersListView.swift
@@ -141,6 +141,9 @@ struct ConversationMembersListView: View {
             in: viewModel.conversation.id,
             contactsRepository: contactsRepository
         )
+        // No dismissal here: `ContactDetailView` pops itself off this stack
+        // once the removal is confirmed. A `dismiss` captured in this closure
+        // would belong to the members list, not to the card pushed from it.
         let onRemove: () -> Void = { viewModel.remove(member: member) }
         ContactDetailView(
             contact: resolvedContact,

--- a/Convos/Conversation Detail/ConversationMembersListView.swift
+++ b/Convos/Conversation Detail/ConversationMembersListView.swift
@@ -142,9 +142,10 @@ struct ConversationMembersListView: View {
             contactsRepository: contactsRepository
         )
         // No dismissal here: `ContactDetailView` pops itself off this stack
-        // once the removal is confirmed. A `dismiss` captured in this closure
-        // would belong to the members list, not to the card pushed from it.
-        let onRemove: () -> Void = { viewModel.remove(member: member) }
+        // once the removal lands, and surfaces the error if it doesn't. A
+        // `dismiss` captured in this closure would belong to the members list,
+        // not to the card pushed from it.
+        let onRemove: () async throws -> Void = { try await viewModel.remove(member: member) }
         ContactDetailView(
             contact: resolvedContact,
             mode: .scopedToConversation(

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1832,7 +1832,6 @@ struct MemberContactDetailSheetContent: View {
     let member: ConversationMember
     @Bindable var profileSettingsViewModel: ProfileSettingsViewModel
     var onStartAgentDm: ((String) -> Void)?
-    @Environment(\.dismiss) private var dismiss: DismissAction
 
     var body: some View {
         let messagingService = viewModel.messagingService
@@ -1843,10 +1842,9 @@ struct MemberContactDetailSheetContent: View {
             in: viewModel.conversation.id,
             contactsRepository: contactsRepository
         )
-        let onRemove: () -> Void = {
-            viewModel.remove(member: member)
-            dismiss()
-        }
+        // Closing the sheet is `ContactDetailView`'s job - it dismisses itself
+        // once the removal is confirmed, so every entry point behaves the same.
+        let onRemove: () -> Void = { viewModel.remove(member: member) }
         NavigationStack {
             ContactDetailView(
                 contact: resolvedContact,

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1843,8 +1843,9 @@ struct MemberContactDetailSheetContent: View {
             contactsRepository: contactsRepository
         )
         // Closing the sheet is `ContactDetailView`'s job - it dismisses itself
-        // once the removal is confirmed, so every entry point behaves the same.
-        let onRemove: () -> Void = { viewModel.remove(member: member) }
+        // once the removal lands and reports the failure otherwise, so every
+        // entry point behaves the same.
+        let onRemove: () async throws -> Void = { try await viewModel.remove(member: member) }
         NavigationStack {
             ContactDetailView(
                 contact: resolvedContact,

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -45,6 +45,17 @@ struct BuilderVoiceMemoSnapshot: Sendable {
     let levels: [Float]
 }
 
+enum ConversationMemberRemovalError: LocalizedError {
+    case notPermitted
+
+    var errorDescription: String? {
+        switch self {
+        case .notPermitted:
+            "Only the person who created this convo can remove members."
+        }
+    }
+}
+
 @MainActor
 @Observable
 class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this type_body_length
@@ -4235,16 +4246,12 @@ extension ConversationViewModel {
         presentingProfileSettings = true
     }
 
-    func remove(member: ConversationMember) {
-        guard canRemoveMembers else { return }
-        Task { [weak self] in
-            guard let self else { return }
-            do {
-                try await metadataWriter.removeMembers([member.profile.inboxId], from: conversation.id)
-            } catch {
-                Log.error("Error removing member: \(error.localizedDescription)")
-            }
-        }
+    /// Throws rather than swallowing the failure so callers can keep their UI
+    /// open and report it - the profile card dismisses itself only once the
+    /// removal has actually landed.
+    func remove(member: ConversationMember) async throws {
+        guard canRemoveMembers else { throw ConversationMemberRemovalError.notPermitted }
+        try await metadataWriter.removeMembers([member.profile.inboxId], from: conversation.id)
     }
 
     private func setNotificationsEnabled(_ enabled: Bool) {


### PR DESCRIPTION
## Problem

Confirming **Remove** on a member left their profile card on screen, showing someone who is no longer in the conversation.

Both entry points render the same `ContactDetailView`, and both route through one confirmation alert — but only one of them cleaned up after itself:

- **Members list** (Conversation info → Members → tap a member): the card is *pushed* onto the info sheet's `NavigationStack`, and had no dismissal at all.
- **Chat tap** (tap a member's avatar/profile in the messages list): presented as a *sheet*, and dismissed itself from the call site in `ConversationView`.

## Fix

Move the dismissal into `ContactDetailView`, next to the confirmation alert that every entry point routes through:

```swift
private func handleRemoveConfirmed() {
    onRemove?()
    dismiss()
}
```

`dismiss` resolves to the right thing in both presentation styles — it pops the pushed card and closes the sheet — which is the same action the card's existing X button (`contact-detail-close`) already relies on.

Because the alert is the single choke point, this covers every presenter of the card, not just the two in the report: members list, chat tap, agent DM page, attachment preview, thinking detail, and agent files.

The now-duplicated `dismiss()` (and its unused `@Environment(\.dismiss)`) is removed from `MemberContactDetailSheetContent` so there is one owner of the behavior. `ConversationMembersListView` gets a comment noting why no `dismiss` belongs in that closure: one captured there would belong to the members list, not to the card pushed from it.

`.standalone` mode never shows Remove (`showRemove` requires `mode.isScopedToConversation`), so the alert — and therefore the new dismissal — only ever fires on conversation-scoped cards.

## Testing

- `xcodebuild build -scheme "Convos (Local)" -configuration Dev -destination "platform=iOS Simulator,name=iPhone 17"` — exits 0, zero errors.
- `swiftlint` — no violations on the three changed files. `swiftformat` — no changes.
- Verified by build and by tracing the presentation code paths; **not** verified by launching the app and removing a real member.
- No existing tests cover this flow, so none needed updating.

## Note

`ConversationMemberView.swift` has its own remove-with-dismiss, but nothing references it except its own `#Preview` — left alone as dead code, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790271578&installation_model_id=20076&pr_number=1428&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1428&signature=49cba38c5f3978472c1a1893f623c2168edf35fc43da05ea54c37eb55006545c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dismiss member profile card only after successful async removal
> - Changes `ConversationViewModel.remove` from a fire-and-forget `Task` to an `async throws` method, adding `ConversationMemberRemovalError.notPermitted` for non-creators and propagating errors to the caller
> - Adds removal state (`isRemovingMember`, `presentingRemoveError`, `removeErrorMessage`) to `ContactDetailView`; the Remove row disables during in-flight removal, the view dismisses only on success, and an error alert shows the localized description on failure
> - Updates all call sites (`ConversationMembersListView`, `ConversationView`, `ConversationMemberView`) to pass async-throwing closures and defer dismissal to `ContactDetailView` instead of dismissing optimistically
> - Risk: `ConversationViewModel.remove` now throws instead of swallowing errors; callers that previously relied on silent failure must handle the thrown `notPermitted` case
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 26a6151.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->