### PR TITLE
Instrument invite and join failures

### DIFF
--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
-        "branch" : "mpr/web-plugins",
-        "revision" : "3638574b2020ab52e73ac18c1af2acb62595d926"
+        "branch" : "jarod/join-failure-telemetry",
+        "revision" : "3197e82eb449be04efab6826d9e3e744cea85884"
       }
     },
     {

--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
-        "branch" : "jarod/join-failure-telemetry",
-        "revision" : "3197e82eb449be04efab6826d9e3e744cea85884"
+        "branch" : "main",
+        "revision" : "e48ac84172bc268709c9c23b18445e85088d8b1b"
       }
     },
     {

--- a/Convos/Contacts/AddFromContactsPickerModifier.swift
+++ b/Convos/Contacts/AddFromContactsPickerModifier.swift
@@ -88,7 +88,14 @@ private struct AddFromContactsPickerModifier: ViewModifier {
         .shareSheet(
             isPresented: $presentingShareSheet,
             items: shareItems,
-            onCompletion: { _, completed, _ in
+            onCompletion: { activityType, completed, _ in
+                ConversationShareReporter.report(
+                    activityType: activityType,
+                    completed: completed,
+                    invite: viewModel.invite,
+                    conversation: viewModel.conversation,
+                    coreActions: viewModel.coreActions
+                )
                 if completed { onInviteShared?() }
             }
         )

--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -29,6 +29,10 @@ struct ContactsView: View {
     /// keeps it (committed visible, marked shared); a cancelled share discards
     /// the still-hidden claimed row so it doesn't linger empty in the chats list.
     @State private var sharedInviteViewModel: NewConversationViewModel?
+    /// The invite actually handed to the share sheet, kept alongside
+    /// `sharedInviteViewModel` so the share outcome can be reported once the
+    /// sheet closes - by which point `invite` has moved on.
+    @State private var sharedInvite: Invite?
     /// Set when "Send an invite" was tapped before an invite exists (the
     /// on-demand claim is still hydrating). Shows a spinner on the row and
     /// lets the `invite?.urlSlug` observer pop the share sheet the moment the
@@ -112,8 +116,8 @@ struct ContactsView: View {
         .shareSheet(
             isPresented: $presentingInviteShareSheet,
             items: inviteShareItems,
-            onCompletion: { _, completed, _ in
-                handleInviteShareCompleted(completed: completed)
+            onCompletion: { activityType, completed, _ in
+                handleInviteShareCompleted(activityType: activityType, completed: completed)
             }
         )
     }
@@ -429,6 +433,7 @@ struct ContactsView: View {
     private func presentInviteShareSheet() {
         guard let invite, let sharedViewModel = inviteConversationViewModel else { return }
         inviteShareURL = invite.inviteURLString
+        sharedInvite = invite
         inviteConversationViewModel = nil
         sharedInviteViewModel = sharedViewModel
         presentingInviteShareSheet = true
@@ -438,9 +443,19 @@ struct ContactsView: View {
     /// closes. A completed share commits it visible and marks its invite shared
     /// so the empty-convo teardown keeps it; a cancelled share discards the
     /// still-hidden claimed row so it doesn't linger empty in the chats list.
-    private func handleInviteShareCompleted(completed: Bool) {
+    private func handleInviteShareCompleted(activityType: UIActivity.ActivityType?, completed: Bool) {
         guard let sharedViewModel = sharedInviteViewModel else { return }
         sharedInviteViewModel = nil
+        if let sharedInvite {
+            ConversationShareReporter.report(
+                activityType: activityType,
+                completed: completed,
+                invite: sharedInvite,
+                conversation: sharedViewModel.conversationViewModel?.conversation,
+                coreActions: coreActions
+            )
+        }
+        sharedInvite = nil
         guard completed else {
             sharedViewModel.cleanUpEmptyEmbeddedInviteIfNeeded()
             return

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -342,6 +342,12 @@ class NewConversationViewModel: Identifiable, Hashable {
     /// state. Cancelled on success, failure, and teardown.
     @ObservationIgnored
     private var joinTimeoutTask: Task<Void, Never>?
+    /// Armed when an invite arrives before the messaging inbox is ready, so
+    /// the code parks in `pendingInviteCode` with no join in flight. That
+    /// wait is the one stuck-"Verifying" shape that reported nothing at all:
+    /// `joinConversation` returns before `armJoinTimeout()` on that path.
+    @ObservationIgnored
+    private var inboxReadinessTimeoutTask: Task<Void, Never>?
     @ObservationIgnored
     private var resetTask: Task<Void, Never>?
     @ObservationIgnored
@@ -497,6 +503,7 @@ class NewConversationViewModel: Identifiable, Hashable {
         newConversationTask?.cancel()
         joinConversationTask?.cancel()
         joinTimeoutTask?.cancel()
+        inboxReadinessTimeoutTask?.cancel()
         resetTask?.cancel()
         stateObservationTask?.cancel()
         optimisticAgentResolveTask?.cancel()
@@ -670,7 +677,7 @@ class NewConversationViewModel: Identifiable, Hashable {
 
         if let pendingCode = pendingInviteCode {
             pendingInviteCode = nil
-            joinConversation(inviteCode: pendingCode)
+            joinConversation(inviteCode: pendingCode, isReplay: true)
         }
 
         if pendingAgentTemplateCreate {
@@ -779,15 +786,31 @@ class NewConversationViewModel: Identifiable, Hashable {
         }
     }
 
-    func joinConversation(inviteCode: String) {
+    /// `isReplay` marks the resumption of an attempt that parked in
+    /// `pendingInviteCode` waiting for the inbox. It is the same attempt the
+    /// user started, so it neither reports a second `join_attempt_started`
+    /// nor restarts the clock - the time spent parked is part of the wait the
+    /// user actually sat through.
+    func joinConversation(inviteCode: String, isReplay: Bool = false) {
         cachedInviteCode = inviteCode
-        verificationStartedAt = CFAbsoluteTimeGetCurrent()
+        if !isReplay || verificationStartedAt == nil {
+            verificationStartedAt = CFAbsoluteTimeGetCurrent()
+        }
+
+        if !isReplay {
+            let startActions: any CoreActions = coreActions
+            let startSource: ConversationSource = joinSource
+            Task { await startActions.joinAttemptStarted(source: startSource) }
+        }
 
         guard let conversationStateManager else {
             pendingInviteCode = inviteCode
+            armInboxReadinessTimeout()
             return
         }
 
+        inboxReadinessTimeoutTask?.cancel()
+        inboxReadinessTimeoutTask = nil
         joinConversationTask?.cancel()
         armJoinTimeout()
         joinConversationTask = Task { [weak self, conversationStateManager] in
@@ -873,6 +896,23 @@ class NewConversationViewModel: Identifiable, Hashable {
         }
     }
 
+    /// The invite landed before the messaging inbox finished coming up, so it
+    /// is parked in `pendingInviteCode` until `configureWithMessagingService`
+    /// replays it. When that replay never happens the user watches
+    /// "Verifying" indefinitely with no request in flight, so this window is
+    /// armed separately from `armJoinTimeout` - which that path never reaches.
+    private func armInboxReadinessTimeout() {
+        inboxReadinessTimeoutTask?.cancel()
+        inboxReadinessTimeoutTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(Constant.joinWaitWindow))
+            guard !Task.isCancelled, let self else { return }
+            self.emitJoinFailure(
+                reason: .inboxNeverReady,
+                attemptNumber: self.consecutiveFailureCount + 1
+            )
+        }
+    }
+
     /// The join request is still unapproved after the wait window: the user
     /// has watched the "Verifying" state the whole time. Emits the
     /// stuck-wait sample as a failed `joined_conversation` outcome;
@@ -883,8 +923,20 @@ class NewConversationViewModel: Identifiable, Hashable {
         guard let startedAt = verificationStartedAt else { return }
         let waitDuration = Float(CFAbsoluteTimeGetCurrent() - startedAt)
         let source: ConversationSource = joinSource
+        let attempt: Int = consecutiveFailureCount + 1
         let actions: any CoreActions = coreActions
-        Task { await actions.joinedConversation(verificationDuration: waitDuration, memberCount: nil, hasAssistant: nil, source: source, isSuccess: false) }
+        Task {
+            await actions.joinedConversation(
+                verificationDuration: waitDuration,
+                memberCount: nil,
+                hasAssistant: nil,
+                source: source,
+                isSuccess: false,
+                failureReason: .approvalTimedOut,
+                creatorReason: nil,
+                attemptNumber: attempt
+            )
+        }
     }
 }
 
@@ -900,6 +952,8 @@ extension NewConversationViewModel {
     private func handleJoinSuccess() {
         joinTimeoutTask?.cancel()
         joinTimeoutTask = nil
+        inboxReadinessTimeoutTask?.cancel()
+        inboxReadinessTimeoutTask = nil
         presentingJoinConversationSheet = false
         displayError = nil
 
@@ -909,13 +963,60 @@ extension NewConversationViewModel {
         verificationStartedAt = nil
         let memberCount: Int = conversationViewModel?.conversation.members.count ?? 0
         let hasAssistant: Bool = conversationViewModel?.conversation.members.contains { $0.isAgent } ?? false
+        let attempt: Int = consecutiveFailureCount + 1
         Task {
             await actions.joinedConversation(
                 verificationDuration: duration,
                 memberCount: memberCount,
                 hasAssistant: hasAssistant,
                 source: source,
-                isSuccess: true
+                isSuccess: true,
+                failureReason: nil,
+                creatorReason: nil,
+                attemptNumber: attempt
+            )
+        }
+    }
+
+    /// Records a conclusive join failure and closes out the attempt.
+    ///
+    /// Both wait windows are cancelled unconditionally - the user is on a
+    /// failure surface now, not the verifying state - while the emit itself
+    /// is gated on `verificationStartedAt`. Clearing that stamp is what makes
+    /// this fire exactly once per attempt: a timer that already fired finds no
+    /// stamp on its next pass, and one still armed is cancelled before it can
+    /// report this same failure again as a full-length stuck wait.
+    ///
+    /// The stamp is also what keeps conversation *creation* failures out of
+    /// the join funnel. `handleErrorState` serves both paths and only a join
+    /// sets it.
+    @MainActor
+    private func emitJoinFailure(
+        reason: JoinFailureReason,
+        attemptNumber: Int,
+        creatorReason: String? = nil
+    ) {
+        joinTimeoutTask?.cancel()
+        joinTimeoutTask = nil
+        inboxReadinessTimeoutTask?.cancel()
+        inboxReadinessTimeoutTask = nil
+
+        guard let startedAt = verificationStartedAt else { return }
+        verificationStartedAt = nil
+
+        let duration = Float(CFAbsoluteTimeGetCurrent() - startedAt)
+        let source: ConversationSource = joinSource
+        let actions: any CoreActions = coreActions
+        Task {
+            await actions.joinedConversation(
+                verificationDuration: duration,
+                memberCount: nil,
+                hasAssistant: nil,
+                source: source,
+                isSuccess: false,
+                failureReason: reason,
+                creatorReason: creatorReason,
+                attemptNumber: attemptNumber
             )
         }
     }
@@ -923,8 +1024,12 @@ extension NewConversationViewModel {
     @MainActor
     private func handleJoinError(_ error: Error) {
         // The user is watching the failure UI now, not the verifying state.
-        joinTimeoutTask?.cancel()
-        joinTimeoutTask = nil
+        // This path threw out of the join task, so no failure has been
+        // counted for it yet.
+        emitJoinFailure(
+            reason: .from(joinError: error),
+            attemptNumber: consecutiveFailureCount + 1
+        )
         withAnimation {
             qrScannerViewModel.resetScanning()
 
@@ -1004,8 +1109,10 @@ extension NewConversationViewModel {
         static let retryDelayMedium: TimeInterval = 4
         static let retryDelayMax: TimeInterval = 8
         /// How long an invite join may sit in the "Verifying" state before
-        /// `conversation_join_timed_out` is emitted. Matches the assistant
-        /// join wait window so the two stuck-wait metrics are comparable.
+        /// it reports a failed `joined_conversation` outcome. Matches the
+        /// assistant join wait window so the two stuck-wait metrics stay
+        /// comparable. Applies to both the approval wait and the
+        /// inbox-readiness wait that precedes it.
         static let joinWaitWindow: TimeInterval = 150
     }
 }
@@ -1193,6 +1300,7 @@ extension NewConversationViewModel {
         newConversationTask?.cancel()
         joinConversationTask?.cancel()
         joinTimeoutTask?.cancel()
+        inboxReadinessTimeoutTask?.cancel()
         pendingVisibilityCommit = false
     }
 
@@ -1463,6 +1571,13 @@ extension NewConversationViewModel {
 
     @MainActor
     private func handleJoinFailedState(_ error: InviteJoinError) {
+        // `consecutiveFailureCount` was incremented by the state dispatch
+        // before this ran, so it is already this attempt's number.
+        emitJoinFailure(
+            reason: .from(inviteJoinErrorType: error.errorType),
+            attemptNumber: consecutiveFailureCount,
+            creatorReason: error.reason
+        )
         cleanUpUIForError()
 
         let inviteCode = extractInviteCode(from: conversationState)
@@ -1488,6 +1603,12 @@ extension NewConversationViewModel {
 
     @MainActor
     private func handleErrorState(_ error: Error) {
+        // No-ops for a creation failure: only a join sets the stamp
+        // `emitJoinFailure` gates on.
+        emitJoinFailure(
+            reason: .from(joinError: error),
+            attemptNumber: consecutiveFailureCount
+        )
         cleanUpUIForError()
         currentError = error
 

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -348,6 +348,14 @@ class NewConversationViewModel: Identifiable, Hashable {
     /// `joinConversation` returns before `armJoinTimeout()` on that path.
     @ObservationIgnored
     private var inboxReadinessTimeoutTask: Task<Void, Never>?
+    /// An attempt reports at most one failed `joined_conversation`, however
+    /// many terminal callbacks it produces: an approval timeout at the wait
+    /// window followed by a `.joinFailed` from the creator's device is one
+    /// failed join, not two. A late approval can still report success after a
+    /// timeout - that pairing is deliberate - so this latches failures only.
+    /// Reset when a new attempt starts.
+    @ObservationIgnored
+    private var joinFailureReported: Bool = false
     @ObservationIgnored
     private var resetTask: Task<Void, Never>?
     @ObservationIgnored
@@ -787,17 +795,23 @@ class NewConversationViewModel: Identifiable, Hashable {
     }
 
     /// `isReplay` marks the resumption of an attempt that parked in
-    /// `pendingInviteCode` waiting for the inbox. It is the same attempt the
-    /// user started, so it neither reports a second `join_attempt_started`
-    /// nor restarts the clock - the time spent parked is part of the wait the
-    /// user actually sat through.
+    /// `pendingInviteCode` waiting for the inbox. While that attempt is still
+    /// open it is the same attempt the user started, so the replay neither
+    /// reports a second `join_attempt_started` nor restarts the clock - the
+    /// time spent parked is part of the wait the user sat through.
+    ///
+    /// A replay landing *after* the parked attempt already reported an outcome
+    /// (its inbox-readiness window elapsed) is a fresh attempt and is started
+    /// and counted as one. Treating it as a continuation would report an
+    /// outcome with no matching start, and a duration measured from the replay
+    /// rather than from anything the user experienced.
     func joinConversation(inviteCode: String, isReplay: Bool = false) {
         cachedInviteCode = inviteCode
-        if !isReplay || verificationStartedAt == nil {
-            verificationStartedAt = CFAbsoluteTimeGetCurrent()
-        }
 
-        if !isReplay {
+        let continuesParkedAttempt: Bool = isReplay && verificationStartedAt != nil
+        if !continuesParkedAttempt {
+            verificationStartedAt = CFAbsoluteTimeGetCurrent()
+            joinFailureReported = false
             let startActions: any CoreActions = coreActions
             let startSource: ConversationSource = joinSource
             Task { await startActions.joinAttemptStarted(source: startSource) }
@@ -920,7 +934,8 @@ class NewConversationViewModel: Identifiable, Hashable {
     /// reports its true duration via the success outcome.
     @MainActor
     private func emitConversationJoinTimedOut() {
-        guard let startedAt = verificationStartedAt else { return }
+        guard !joinFailureReported, let startedAt = verificationStartedAt else { return }
+        joinFailureReported = true
         let waitDuration = Float(CFAbsoluteTimeGetCurrent() - startedAt)
         let source: ConversationSource = joinSource
         let attempt: Int = consecutiveFailureCount + 1
@@ -961,6 +976,7 @@ extension NewConversationViewModel {
         let source: ConversationSource = joinSource
         let duration: Float = verificationStartedAt.map { Float(CFAbsoluteTimeGetCurrent() - $0) } ?? 0
         verificationStartedAt = nil
+        joinFailureReported = false
         let memberCount: Int = conversationViewModel?.conversation.members.count ?? 0
         let hasAssistant: Bool = conversationViewModel?.conversation.members.contains { $0.isAgent } ?? false
         let attempt: Int = consecutiveFailureCount + 1
@@ -981,15 +997,14 @@ extension NewConversationViewModel {
     /// Records a conclusive join failure and closes out the attempt.
     ///
     /// Both wait windows are cancelled unconditionally - the user is on a
-    /// failure surface now, not the verifying state - while the emit itself
-    /// is gated on `verificationStartedAt`. Clearing that stamp is what makes
-    /// this fire exactly once per attempt: a timer that already fired finds no
-    /// stamp on its next pass, and one still armed is cancelled before it can
-    /// report this same failure again as a full-length stuck wait.
+    /// failure surface now, not the verifying state - while the emit is gated
+    /// on two things. `joinFailureReported` keeps an attempt to a single
+    /// failure: a wait window that already elapsed and then a terminal
+    /// callback for the same join is one failed outcome, not two.
     ///
-    /// The stamp is also what keeps conversation *creation* failures out of
-    /// the join funnel. `handleErrorState` serves both paths and only a join
-    /// sets it.
+    /// `verificationStartedAt` keeps conversation *creation* failures out of
+    /// the join funnel entirely - `handleErrorState` serves both paths and
+    /// only a join sets the stamp.
     @MainActor
     private func emitJoinFailure(
         reason: JoinFailureReason,
@@ -1001,7 +1016,8 @@ extension NewConversationViewModel {
         inboxReadinessTimeoutTask?.cancel()
         inboxReadinessTimeoutTask = nil
 
-        guard let startedAt = verificationStartedAt else { return }
+        guard !joinFailureReported, let startedAt = verificationStartedAt else { return }
+        joinFailureReported = true
         verificationStartedAt = nil
 
         let duration = Float(CFAbsoluteTimeGetCurrent() - startedAt)

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -356,6 +356,13 @@ class NewConversationViewModel: Identifiable, Hashable {
     /// Reset when a new attempt starts.
     @ObservationIgnored
     private var joinFailureReported: Bool = false
+    /// The 1-based attempt number of the join in flight, captured when the
+    /// attempt starts. It cannot be derived at outcome time:
+    /// `consecutiveFailureCount` is reset by `.ready` before the join task
+    /// reaches `handleJoinSuccess`, so a join that succeeded on the third try
+    /// would report itself as the first.
+    @ObservationIgnored
+    private var currentJoinAttemptNumber: Int = 1
     @ObservationIgnored
     private var resetTask: Task<Void, Never>?
     @ObservationIgnored
@@ -812,6 +819,7 @@ class NewConversationViewModel: Identifiable, Hashable {
         if !continuesParkedAttempt {
             verificationStartedAt = CFAbsoluteTimeGetCurrent()
             joinFailureReported = false
+            currentJoinAttemptNumber = consecutiveFailureCount + 1
             let startActions: any CoreActions = coreActions
             let startSource: ConversationSource = joinSource
             Task { await startActions.joinAttemptStarted(source: startSource) }
@@ -920,10 +928,7 @@ class NewConversationViewModel: Identifiable, Hashable {
         inboxReadinessTimeoutTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(Constant.joinWaitWindow))
             guard !Task.isCancelled, let self else { return }
-            self.emitJoinFailure(
-                reason: .inboxNeverReady,
-                attemptNumber: self.consecutiveFailureCount + 1
-            )
+            self.emitJoinFailure(reason: .inboxNeverReady)
         }
     }
 
@@ -938,7 +943,7 @@ class NewConversationViewModel: Identifiable, Hashable {
         joinFailureReported = true
         let waitDuration = Float(CFAbsoluteTimeGetCurrent() - startedAt)
         let source: ConversationSource = joinSource
-        let attempt: Int = consecutiveFailureCount + 1
+        let attempt: Int = currentJoinAttemptNumber
         let actions: any CoreActions = coreActions
         Task {
             await actions.joinedConversation(
@@ -979,7 +984,7 @@ extension NewConversationViewModel {
         joinFailureReported = false
         let memberCount: Int = conversationViewModel?.conversation.members.count ?? 0
         let hasAssistant: Bool = conversationViewModel?.conversation.members.contains { $0.isAgent } ?? false
-        let attempt: Int = consecutiveFailureCount + 1
+        let attempt: Int = currentJoinAttemptNumber
         Task {
             await actions.joinedConversation(
                 verificationDuration: duration,
@@ -1008,7 +1013,6 @@ extension NewConversationViewModel {
     @MainActor
     private func emitJoinFailure(
         reason: JoinFailureReason,
-        attemptNumber: Int,
         creatorReason: String? = nil
     ) {
         joinTimeoutTask?.cancel()
@@ -1032,7 +1036,7 @@ extension NewConversationViewModel {
                 isSuccess: false,
                 failureReason: reason,
                 creatorReason: creatorReason,
-                attemptNumber: attemptNumber
+                attemptNumber: currentJoinAttemptNumber
             )
         }
     }
@@ -1042,10 +1046,7 @@ extension NewConversationViewModel {
         // The user is watching the failure UI now, not the verifying state.
         // This path threw out of the join task, so no failure has been
         // counted for it yet.
-        emitJoinFailure(
-            reason: .from(joinError: error),
-            attemptNumber: consecutiveFailureCount + 1
-        )
+        emitJoinFailure(reason: .from(joinError: error))
         withAnimation {
             qrScannerViewModel.resetScanning()
 
@@ -1591,7 +1592,6 @@ extension NewConversationViewModel {
         // before this ran, so it is already this attempt's number.
         emitJoinFailure(
             reason: .from(inviteJoinErrorType: error.errorType),
-            attemptNumber: consecutiveFailureCount,
             creatorReason: error.reason
         )
         cleanUpUIForError()
@@ -1621,10 +1621,7 @@ extension NewConversationViewModel {
     private func handleErrorState(_ error: Error) {
         // No-ops for a creation failure: only a join sets the stamp
         // `emitJoinFailure` gates on.
-        emitJoinFailure(
-            reason: .from(joinError: error),
-            attemptNumber: consecutiveFailureCount
-        )
+        emitJoinFailure(reason: .from(joinError: error))
         cleanUpUIForError()
         currentError = error
 

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -109,6 +109,18 @@ struct ConversationInfoView: View {
         guard !invite.isEmpty else { return [] }
         return [invite.inviteURLString]
     }
+
+    private var handleInviteShareCompletion: (UIActivity.ActivityType?, Bool, Error?) -> Void {
+        { activityType, completed, _ in
+            ConversationShareReporter.report(
+                activityType: activityType,
+                completed: completed,
+                invite: viewModel.invite,
+                conversation: viewModel.conversation,
+                coreActions: viewModel.coreActions
+            )
+        }
+    }
     @State private var presentingAddFromContactsPicker: Bool = false
     @State private var exportedLogsURL: URL?
     @State private var metadataDebugText: String = "Loading…"
@@ -395,7 +407,8 @@ struct ConversationInfoView: View {
             )
             .shareSheet(
                 isPresented: $presentingInviteShareSheet,
-                items: inviteShareItems
+                items: inviteShareItems,
+                onCompletion: handleInviteShareCompletion
             )
             .onAppear {
                 ensureNavigator()

--- a/Convos/Conversation Detail/ConversationMembersListView.swift
+++ b/Convos/Conversation Detail/ConversationMembersListView.swift
@@ -17,6 +17,18 @@ struct ConversationMembersListView: View {
         guard !invite.isEmpty else { return [] }
         return [invite.inviteURLString]
     }
+
+    private var handleInviteShareCompletion: (UIActivity.ActivityType?, Bool, Error?) -> Void {
+        { activityType, completed, _ in
+            ConversationShareReporter.report(
+                activityType: activityType,
+                completed: completed,
+                invite: viewModel.invite,
+                conversation: viewModel.conversation,
+                coreActions: viewModel.coreActions
+            )
+        }
+    }
     @State private var navState: MembersListNavigatorImpl = .init()
     @State private var navigator: MembersListCollector?
 
@@ -55,7 +67,8 @@ struct ConversationMembersListView: View {
             )
             .shareSheet(
                 isPresented: $presentingInviteShareSheet,
-                items: inviteShareItems
+                items: inviteShareItems,
+                onCompletion: handleInviteShareCompletion
             )
             .onAppear {
                 ensureNavigator()

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1620,7 +1620,14 @@ private extension ConversationView {
                 }
                 presentingAddFromContactsPicker = true
             },
-            showMembersList: { viewModel.presentingConversationSettings = true }
+            showMembersList: { viewModel.presentingConversationSettings = true },
+            // Same destination the member card's agent action opens, so the
+            // web surface and the native one agree on what "the agent DM" is.
+            showAgentDm: {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    selectTab(.agent)
+                }
+            }
         )
     }
 

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1237,7 +1237,14 @@ private extension ConversationView {
     /// link is out in the world, so the empty-convo teardown must not
     /// reclaim it (see `onInviteShared`).
     private var handleInviteShareCompletion: (UIActivity.ActivityType?, Bool, Error?) -> Void {
-        { _, completed, _ in
+        { activityType, completed, _ in
+            ConversationShareReporter.report(
+                activityType: activityType,
+                completed: completed,
+                invite: viewModel.invite,
+                conversation: viewModel.conversation,
+                coreActions: viewModel.coreActions
+            )
             guard completed else { return }
             onInviteShared?()
         }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1120,6 +1120,16 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     @ObservationIgnored
     private var assistantJoinTimeoutTask: Task<Void, Never>?
 
+    /// Telemetry anchors for the invite-acceptance wait behind the drawer's
+    /// "Verifying" state. Set only when this view model opens a conversation
+    /// whose invite is already pending - a live join starts from a draft
+    /// conversation and is measured by `NewConversationViewModel`, so the two
+    /// surfaces cannot report the same wait twice.
+    @ObservationIgnored
+    private var inviteAcceptanceWaitStartedAt: Date?
+    @ObservationIgnored
+    private var inviteAcceptanceTimeoutTask: Task<Void, Never>?
+
     var sendReadReceipts: Bool = true
     var isViewingConversation: Bool = false
 
@@ -1187,6 +1197,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         // tying it to the view lifecycle was cancelling joins mid-request, so
         // the backend never provisioned the agent.
         explodeDurationTask?.cancel()
+        inviteAcceptanceTimeoutTask?.cancel()
         agentBuilderPlaceholderExpiryTask?.cancel()
         pendingSyntheticAgentExpiryTask?.cancel()
         assistantJoinTimeoutTask?.cancel()
@@ -1305,6 +1316,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
 
         if conversation.isPendingInvite {
             onboardingCoordinator.isWaitingForInviteAcceptance = true
+            beginInviteAcceptanceWait()
         }
         startOnboarding()
         registerInlineAttachmentRecovery()
@@ -2117,6 +2129,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     }
 
     func inviteWasAccepted() {
+        clearInviteAcceptanceWait()
         Task { @MainActor in
             await onboardingCoordinator.inviteWasAccepted(for: conversation.id)
         }
@@ -3249,6 +3262,11 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         /// window in SyncingManager, which itself covers the assistant
         /// backend's roughly two-minute give-up with margin.
         static let assistantJoinWaitWindow: TimeInterval = 150
+        /// How long the drawer's "Verifying" state is measured before it
+        /// reports a failed `joined_conversation`. Matches the invite-join
+        /// wait window in `NewConversationViewModel` so the two stuck-wait
+        /// samples stay comparable.
+        static let inviteAcceptanceWaitWindow: TimeInterval = 150
         /// Shown in the approval sheet when an approval could not be
         /// completed (backend grant confirmation or result send failed).
         static let capabilityApprovalFailedMessage: String =
@@ -4486,6 +4504,60 @@ extension ConversationViewModel {
             assistantJoinWaitSource = source
         }
         armAssistantJoinTimeout()
+    }
+
+    /// Starts measuring the drawer's "Verifying" wait. This surface
+    /// previously had neither a timer nor any telemetry: a pending invite the
+    /// creator never approved spun here indefinitely and reported nothing.
+    private func beginInviteAcceptanceWait() {
+        inviteAcceptanceWaitStartedAt = Date()
+        armInviteAcceptanceTimeout()
+    }
+
+    private func armInviteAcceptanceTimeout() {
+        inviteAcceptanceTimeoutTask?.cancel()
+        guard let startedAt = inviteAcceptanceWaitStartedAt else { return }
+        let elapsed = Date().timeIntervalSince(startedAt)
+        let remaining: TimeInterval = max(0, Constant.inviteAcceptanceWaitWindow - elapsed)
+        inviteAcceptanceTimeoutTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(remaining))
+            guard !Task.isCancelled else { return }
+            self?.emitInviteAcceptanceTimedOut()
+        }
+    }
+
+    /// The invite was still unapproved when the wait window elapsed.
+    ///
+    /// `source` reports `.url` because the original entry point is not
+    /// persisted on the conversation: this surface is reached by opening an
+    /// already-pending convo, often in a later session, by which point the
+    /// scan / paste / url distinction is gone. `failure_reason` is the
+    /// load-bearing dimension here, not `source`.
+    private func emitInviteAcceptanceTimedOut() {
+        guard let startedAt = inviteAcceptanceWaitStartedAt else { return }
+        inviteAcceptanceWaitStartedAt = nil
+        guard conversation.isPendingInvite else { return }
+
+        let waitDuration = Float(Date().timeIntervalSince(startedAt))
+        let actions: any CoreActions = coreActions
+        Task {
+            await actions.joinedConversation(
+                verificationDuration: waitDuration,
+                memberCount: nil,
+                hasAssistant: nil,
+                source: .url,
+                isSuccess: false,
+                failureReason: .approvalTimedOut,
+                creatorReason: nil,
+                attemptNumber: 1
+            )
+        }
+    }
+
+    private func clearInviteAcceptanceWait() {
+        inviteAcceptanceWaitStartedAt = nil
+        inviteAcceptanceTimeoutTask?.cancel()
+        inviteAcceptanceTimeoutTask = nil
     }
 
     private func armAssistantJoinTimeout() {

--- a/Convos/Conversation Detail/Home/HomeBridgePlugins.swift
+++ b/Convos/Conversation Detail/Home/HomeBridgePlugins.swift
@@ -15,6 +15,7 @@ struct HomeBridgeNavigation {
     }
     var showInvitePicker: @MainActor @Sendable () -> Void = {}
     var showMembersList: @MainActor @Sendable () -> Void = {}
+    var showAgentDm: @MainActor @Sendable () -> Void = {}
 }
 
 /// Main-actor state shared between the hosting web view (which refreshes the
@@ -130,6 +131,11 @@ private final class HomeChatPlugin: ChatPlugin, Sendable {
     func showMembersList() {
         let host = host
         Task { @MainActor in host.navigation.showMembersList() }
+    }
+
+    func showAgentDm() {
+        let host = host
+        Task { @MainActor in host.navigation.showAgentDm() }
     }
 
     func getAgentStatus() async throws -> AgentStatus {

--- a/Convos/Metrics/ConversationShareReporter.swift
+++ b/Convos/Metrics/ConversationShareReporter.swift
@@ -1,0 +1,60 @@
+import ConvosCore
+import ConvosMetrics
+import UIKit
+
+/// Reports `shared_conversation` for the invite share sheet.
+///
+/// The event has been in the metrics catalog since the funnel was defined
+/// and implemented in `MetricsCoreActions`, but nothing ever called it, so
+/// invite distribution - the denominator behind every join number - went
+/// unmeasured. All five invite share surfaces route through the same
+/// `shareSheet` modifier, so they all report through here.
+enum ConversationShareReporter {
+    /// Maps the activity the user picked onto the metric's dimension.
+    ///
+    /// A dismissed sheet reports `.cancelled` rather than going unrecorded,
+    /// so abandonment stays visible: a share surface people open and back
+    /// out of looks identical to one they never opened otherwise.
+    static func shareTarget(
+        for activityType: UIActivity.ActivityType?,
+        completed: Bool
+    ) -> ShareTarget {
+        guard completed, let activityType else { return .cancelled }
+
+        switch activityType {
+        case .message: return .messages
+        case .mail: return .mail
+        case .copyToPasteboard: return .copy
+        case .airDrop: return .airdrop
+        default: return .other
+        }
+    }
+
+    static func report(
+        activityType: UIActivity.ActivityType?,
+        completed: Bool,
+        invite: Invite,
+        conversation: Conversation?,
+        coreActions: any CoreActions
+    ) {
+        // Nothing was shareable, so the sheet carried no invite.
+        guard !invite.isEmpty else { return }
+
+        let target: ShareTarget = shareTarget(for: activityType, completed: completed)
+        let memberCount: Int = conversation?.members.count ?? 0
+        let hasAssistant: Bool = conversation?.members.contains { $0.isAgent } ?? false
+        let hasExpiration: Bool = invite.expiresAt != nil
+        let expiresAfterUse: Bool = invite.expiresAfterUse
+
+        Task {
+            await coreActions.sharedConversation(
+                memberCount: memberCount,
+                hasAssistant: hasAssistant,
+                shareTarget: target,
+                hasExpiration: hasExpiration,
+                expiresAfterUse: expiresAfterUse,
+                isSuccess: completed
+            )
+        }
+    }
+}

--- a/Convos/Metrics/PostHogCollector.swift
+++ b/Convos/Metrics/PostHogCollector.swift
@@ -54,15 +54,52 @@ final class PostHogCollector: CollectorDelegate {
     }
 
     /// Engineering diagnostics that should alert through Sentry rather than
-    /// only landing in product analytics: a poll-rescued assistant join is
-    /// direct evidence of a silently dead message stream. No-op when the
-    /// SDK isn't started (local/test builds) and carries no PII - only the
-    /// stream-staleness numbers from the metric.
+    /// only landing in product analytics. No-op when the SDK isn't started
+    /// (local/test builds).
     private func captureDiagnosticEventInSentry(name: String, properties: [String: Any?]) {
-        guard name == MetricsCoreActions.eventAssistantJoinRescuedByPolling else { return }
+        guard let message = diagnosticMessage(for: name, properties: properties) else { return }
         let event = Event(level: .warning)
-        event.message = SentryMessage(formatted: "assistant join rescued by polling - message stream likely dead")
+        event.message = SentryMessage(formatted: message)
         event.extra = properties.compactMapValues { $0 }
         SentrySDK.capture(event: event)
     }
+
+    /// The message doubles as the Sentry grouping key, so each failure cause
+    /// gets its own issue rather than one bucket of every failed join.
+    ///
+    /// Carries no PII: the join properties are the classified failure reason,
+    /// timing numbers, and the creator device's own diagnostic string, which
+    /// is hand-authored at each rejection site and bounded to 500 characters.
+    private func diagnosticMessage(for name: String, properties: [String: Any?]) -> String? {
+        switch name {
+        case MetricsCoreActions.eventAssistantJoinRescuedByPolling:
+            return "assistant join rescued by polling - message stream likely dead"
+        case MetricsCoreActions.eventJoinedConversation:
+            return failedJoinMessage(properties: properties)
+        default:
+            return nil
+        }
+    }
+
+    /// Only the causes that mean something is broken on our side reach Sentry.
+    /// An unapproved invite, an expired convo, or a dropped connection are
+    /// expected outcomes with real volume - they belong in the funnel, not in
+    /// an issue tracker, and routing them here would bury the rest.
+    private func failedJoinMessage(properties: [String: Any?]) -> String? {
+        let isSuccess: Bool? = properties[MetricsCoreActions.paramIsSuccess].flatMap { $0 } as? Bool
+        guard isSuccess == false else { return nil }
+
+        let rawReason: String? = properties[MetricsCoreActions.paramFailureReason].flatMap { $0 } as? String
+        let reason: String = rawReason ?? JoinFailureReason.unknown.metricsString
+        guard Self.sentryReportedJoinFailures.contains(reason) else { return nil }
+
+        return "invite join failed - \(reason)"
+    }
+
+    private static let sentryReportedJoinFailures: Set<String> = [
+        JoinFailureReason.inboxNeverReady.metricsString,
+        JoinFailureReason.signatureVerificationFailed.metricsString,
+        JoinFailureReason.internalStorageError.metricsString,
+        JoinFailureReason.unknown.metricsString,
+    ]
 }

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "28dfd1ca67a57621dbd11fe70e5e00d3317acd3a9c2d5c0220582f5b8dfa43f9",
+  "originHash" : "3668a2f53614d6611437a51d63f0034463af23c02a8fd3f06dac49063020da38",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
-        "branch" : "mpr/web-plugins",
-        "revision" : "3638574b2020ab52e73ac18c1af2acb62595d926"
+        "branch" : "jarod/join-failure-telemetry",
+        "revision" : "3197e82eb449be04efab6826d9e3e744cea85884"
       }
     },
     {

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
-        "branch" : "jarod/join-failure-telemetry",
-        "revision" : "3197e82eb449be04efab6826d9e3e744cea85884"
+        "branch" : "main",
+        "revision" : "e48ac84172bc268709c9c23b18445e85088d8b1b"
       }
     },
     {

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -39,13 +39,7 @@ let package = Package(
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.1"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "8.57.1"),
-        // Temporary pin: JoinFailureReason and the extended joinedConversation
-        // signature land in convos-shared#10. That branch is cut from
-        // mpr/web-plugins rather than main deliberately - main's ChatPlugin
-        // gained showAgentDm(), which HomeChatPlugin has not adopted, so
-        // pinning main fails to build for reasons unrelated to this change.
-        // Revert to branch: "main" once #10 merges and showAgentDm is wired.
-        .package(url: "https://github.com/xmtplabs/convos-shared.git", branch: "jarod/join-failure-telemetry"),
+        .package(url: "https://github.com/xmtplabs/convos-shared.git", branch: "main"),
         .package(path: "../ConvosLogging"),
         .package(path: "../ConvosInvites"),
         .package(path: "../ConvosAppData"),

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -39,9 +39,13 @@ let package = Package(
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.1"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "8.57.1"),
-        // Temporary pin: the ConvosBridge product only exists on the web-plugins
-        // branch so far; revert to branch: "main" once that PR merges in convos-shared.
-        .package(url: "https://github.com/xmtplabs/convos-shared.git", branch: "mpr/web-plugins"),
+        // Temporary pin: JoinFailureReason and the extended joinedConversation
+        // signature land in convos-shared#10. That branch is cut from
+        // mpr/web-plugins rather than main deliberately - main's ChatPlugin
+        // gained showAgentDm(), which HomeChatPlugin has not adopted, so
+        // pinning main fails to build for reasons unrelated to this change.
+        // Revert to branch: "main" once #10 merges and showAgentDm is wired.
+        .package(url: "https://github.com/xmtplabs/convos-shared.git", branch: "jarod/join-failure-telemetry"),
         .package(path: "../ConvosLogging"),
         .package(path: "../ConvosInvites"),
         .package(path: "../ConvosAppData"),

--- a/ConvosCore/Sources/ConvosCore/Metrics/JoinFailureReason+Mapping.swift
+++ b/ConvosCore/Sources/ConvosCore/Metrics/JoinFailureReason+Mapping.swift
@@ -1,0 +1,69 @@
+import ConvosInvites
+import ConvosMetrics
+import Foundation
+
+/// Translates the join-path error taxonomies into the single dimension the
+/// `joined_conversation` funnel reports.
+///
+/// Three separate types classify a failed join today - the state machine's
+/// own errors, the network kinds it string-matches out of underlying
+/// transport errors, and the rejection the creator's device sends back over
+/// the join DM. All three are computed to pick user-facing copy and were
+/// otherwise discarded; these mappings are what carry them into telemetry.
+public extension JoinFailureReason {
+    /// A rejection reported by the conversation creator's device.
+    ///
+    /// `.genericFailure` stays `.unknown` deliberately: it is the creator's
+    /// catch-all, and the accompanying `InviteJoinError.reason` string is
+    /// what actually distinguishes those cases.
+    static func from(inviteJoinErrorType errorType: InviteJoinErrorType) -> JoinFailureReason {
+        switch errorType {
+        case .conversationExpired: return .conversationExpired
+        case .conversationNotFound: return .conversationNotFound
+        case .consentNotAllowed: return .consentNotAllowed
+        case .genericFailure: return .unknown
+        }
+    }
+
+    /// A failure raised locally by the conversation state machine.
+    ///
+    /// Transport classification wins over the case itself, because
+    /// `.stateMachineError` wraps the underlying error that
+    /// `networkErrorKind` inspects - checking the case first would collapse
+    /// every network failure into `.unknown`.
+    static func from(conversationStateMachineError error: ConversationStateMachineError) -> JoinFailureReason {
+        if let kind = error.networkErrorKind {
+            return .from(networkErrorKind: kind)
+        }
+
+        switch error {
+        case .inviteExpired: return .inviteExpired
+        case .conversationExpired: return .conversationExpired
+        case .failedFindingConversation: return .conversationNotFound
+        case .failedVerifyingSignature: return .signatureVerificationFailed
+        case .invalidInviteCodeFormat: return .invalidCodeFormat
+        case .noConversationStateManager: return .inboxNeverReady
+        case .timedOut: return .networkTimedOut
+        case .stateMachineError, .addMembersFailed: return .unknown
+        }
+    }
+
+    static func from(networkErrorKind kind: ConversationStateMachineError.NetworkErrorKind) -> JoinFailureReason {
+        switch kind {
+        case .serviceUnavailable: return .networkServiceUnavailable
+        case .timedOut: return .networkTimedOut
+        case .connectionLost: return .networkConnectionLost
+        case .tlsFailure: return .networkTlsFailure
+        case .internalError: return .internalStorageError
+        }
+    }
+
+    /// Any error surfaced on the join path. Errors that are not state-machine
+    /// errors reach analytics as `.unknown` rather than being dropped.
+    static func from(joinError error: Error) -> JoinFailureReason {
+        guard let stateMachineError = error as? ConversationStateMachineError else {
+            return .unknown
+        }
+        return .from(conversationStateMachineError: stateMachineError)
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Metrics/NoOpCoreActions.swift
+++ b/ConvosCore/Sources/ConvosCore/Metrics/NoOpCoreActions.swift
@@ -6,15 +6,21 @@ public final class NoOpCoreActions: CoreActions, @unchecked Sendable {
 
     public func startedConversation() async {}
 
+    public func joinAttemptStarted(source: ConversationSource) async {}
+
+    // swiftlint:disable:next function_parameter_count
     public func joinedConversation(
         verificationDuration: Float,
         memberCount: Int?,
         hasAssistant: Bool?,
         source: ConversationSource,
-        isSuccess: Bool
+        isSuccess: Bool,
+        failureReason: JoinFailureReason?,
+        creatorReason: String?,
+        attemptNumber: Int
     ) async {}
 
-    public func invitedToConversation(memberCount: Int, hasAssistant: Bool) async {}
+    public func invitedToConversation(memberCount: Int, hasAssistant: Bool, isSuccess: Bool) async {}
 
     public func addedAssistant(memberCount: Int) async {}
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/InviteWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/InviteWriter.swift
@@ -33,25 +33,25 @@ class InviteWriter: InviteWriterProtocol {
         expiresAt: Date? = nil,
         expiresAfterUse: Bool = false
     ) async throws -> Invite {
-        guard let identity = try await identityStore.load() else {
-            throw KeychainIdentityStoreError.identityNotFound("No identity available to sign invite for conversation \(conversation.id)")
-        }
-        let currentInboxId = identity.inboxId
-
-        if let existingInvite = try? await self.databaseWriter.read({ db in
-            try? DBInvite
-                .filter(DBInvite.Columns.conversationId == conversation.id)
-                .filter(DBInvite.Columns.creatorInboxId == currentInboxId)
-                .fetchOne(db)
-        }) {
-            if inviteTagMatches(slug: existingInvite.urlSlug, tag: conversation.inviteTag) {
-                return existingInvite.hydrateInvite()
-            }
-            try await delete(for: conversation.id)
-            Log.info("Invite tag changed for conversation \(conversation.id), re-creating invite")
-        }
-
         do {
+            guard let identity = try await identityStore.load() else {
+                throw KeychainIdentityStoreError.identityNotFound("No identity available to sign invite for conversation \(conversation.id)")
+            }
+            let currentInboxId = identity.inboxId
+
+            if let existingInvite = try? await self.databaseWriter.read({ db in
+                try? DBInvite
+                    .filter(DBInvite.Columns.conversationId == conversation.id)
+                    .filter(DBInvite.Columns.creatorInboxId == currentInboxId)
+                    .fetchOne(db)
+            }) {
+                if inviteTagMatches(slug: existingInvite.urlSlug, tag: conversation.inviteTag) {
+                    return existingInvite.hydrateInvite()
+                }
+                try await delete(for: conversation.id)
+                Log.info("Invite tag changed for conversation \(conversation.id), re-creating invite")
+            }
+
             let privateKey: Data = identity.keys.privateKey.secp256K1.bytes
             let urlSlug = try SignedInvite.slug(
                 for: conversation,
@@ -107,18 +107,28 @@ class InviteWriter: InviteWriterProtocol {
             return dbInvite.hydrateInvite()
         } catch {
             Log.warning("Failed to create invite for conversation \(conversation.id), will retry on next sync: \(error)")
-            // A conversation with no invite cannot be joined at all, so a
-            // mint that throws is the earliest point the invite funnel can
-            // break. It previously reached nothing but this local warning.
-            let actions: any CoreActions = coreActions
-            Task {
-                await actions.invitedToConversation(
-                    memberCount: 0,
-                    hasAssistant: false,
-                    isSuccess: false
-                )
-            }
+            reportInviteCreationFailed()
             throw error
+        }
+    }
+
+    /// A conversation with no invite cannot be joined at all, so a mint that
+    /// fails is the earliest point the invite funnel can break. Every throwing
+    /// exit from `generate` reports here - the identity load and the preflight
+    /// delete included, which is why they sit inside the instrumented `do`.
+    /// All of it previously reached nothing but a local warning.
+    ///
+    /// `memberCount` / `hasAssistant` report 0 / false because the counts are
+    /// read from the write that failed; `isSuccess` is what separates these
+    /// from real samples.
+    private func reportInviteCreationFailed() {
+        let actions: any CoreActions = coreActions
+        Task {
+            await actions.invitedToConversation(
+                memberCount: 0,
+                hasAssistant: false,
+                isSuccess: false
+            )
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/InviteWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/InviteWriter.swift
@@ -100,12 +100,24 @@ class InviteWriter: InviteWriterProtocol {
             Task {
                 await actions.invitedToConversation(
                     memberCount: memberCount,
-                    hasAssistant: hasAssistant
+                    hasAssistant: hasAssistant,
+                    isSuccess: true
                 )
             }
             return dbInvite.hydrateInvite()
         } catch {
             Log.warning("Failed to create invite for conversation \(conversation.id), will retry on next sync: \(error)")
+            // A conversation with no invite cannot be joined at all, so a
+            // mint that throws is the earliest point the invite funnel can
+            // break. It previously reached nothing but this local warning.
+            let actions: any CoreActions = coreActions
+            Task {
+                await actions.invitedToConversation(
+                    memberCount: 0,
+                    hasAssistant: false,
+                    isSuccess: false
+                )
+            }
             throw error
         }
     }

--- a/ConvosCore/Tests/ConvosCoreTests/JoinFailureReasonMappingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/JoinFailureReasonMappingTests.swift
@@ -1,0 +1,86 @@
+@testable import ConvosCore
+import ConvosInvites
+import ConvosMetrics
+import Foundation
+import Testing
+
+private struct StubUnderlyingError: Error, CustomStringConvertible {
+    let description: String
+}
+
+private struct StubUnrelatedError: Error {}
+
+@Suite("JoinFailureReason mapping")
+struct JoinFailureReasonMappingTests {
+    // MARK: - Creator-side rejections
+
+    @Test("maps every creator rejection type")
+    func mapsInviteJoinErrorTypes() {
+        #expect(JoinFailureReason.from(inviteJoinErrorType: .conversationExpired) == .conversationExpired)
+        #expect(JoinFailureReason.from(inviteJoinErrorType: .conversationNotFound) == .conversationNotFound)
+        #expect(JoinFailureReason.from(inviteJoinErrorType: .consentNotAllowed) == .consentNotAllowed)
+    }
+
+    @Test("leaves the creator's catch-all as unknown so creatorReason carries the detail")
+    func mapsGenericFailureToUnknown() {
+        #expect(JoinFailureReason.from(inviteJoinErrorType: .genericFailure) == .unknown)
+    }
+
+    // MARK: - State machine errors
+
+    @Test("maps the non-network state machine cases")
+    func mapsStateMachineCases() {
+        #expect(JoinFailureReason.from(conversationStateMachineError: .inviteExpired) == .inviteExpired)
+        #expect(JoinFailureReason.from(conversationStateMachineError: .conversationExpired) == .conversationExpired)
+        #expect(JoinFailureReason.from(conversationStateMachineError: .failedFindingConversation) == .conversationNotFound)
+        #expect(JoinFailureReason.from(conversationStateMachineError: .failedVerifyingSignature) == .signatureVerificationFailed)
+        #expect(JoinFailureReason.from(conversationStateMachineError: .invalidInviteCodeFormat("bad")) == .invalidCodeFormat)
+        #expect(JoinFailureReason.from(conversationStateMachineError: .noConversationStateManager) == .inboxNeverReady)
+    }
+
+    @Test("maps .timedOut through the network classification")
+    func mapsTimedOut() {
+        #expect(JoinFailureReason.from(conversationStateMachineError: .timedOut) == .networkTimedOut)
+    }
+
+    // MARK: - Network classification precedence
+
+    /// `.stateMachineError` wraps the underlying transport error, so checking
+    /// the enum case before `networkErrorKind` would collapse every network
+    /// failure into `.unknown`. These pin that ordering.
+    @Test(
+        "classifies wrapped transport errors ahead of the enum case",
+        arguments: [
+            ("dns error", JoinFailureReason.networkServiceUnavailable),
+            ("service is currently unavailable", .networkServiceUnavailable),
+            ("request timed out", .networkTimedOut),
+            ("The network connection was lost.", .networkConnectionLost),
+            ("A TLS error caused the secure connection to fail.", .networkTlsFailure),
+            ("storage error", .internalStorageError),
+            ("SequenceId not found", .internalStorageError),
+        ]
+    )
+    func classifiesWrappedTransportErrors(message: String, expected: JoinFailureReason) {
+        let error = ConversationStateMachineError.stateMachineError(StubUnderlyingError(description: message))
+        #expect(JoinFailureReason.from(conversationStateMachineError: error) == expected)
+    }
+
+    @Test("falls back to unknown for an unclassifiable wrapped error")
+    func unclassifiableWrappedErrorIsUnknown() {
+        let error = ConversationStateMachineError.stateMachineError(StubUnderlyingError(description: "something else entirely"))
+        #expect(JoinFailureReason.from(conversationStateMachineError: error) == .unknown)
+    }
+
+    // MARK: - Untyped join errors
+
+    @Test("routes a state machine error through the typed mapping")
+    func joinErrorRoutesToTypedMapping() {
+        let error: Error = ConversationStateMachineError.inviteExpired
+        #expect(JoinFailureReason.from(joinError: error) == .inviteExpired)
+    }
+
+    @Test("records an unrelated error as unknown rather than dropping it")
+    func unrelatedErrorIsUnknown() {
+        #expect(JoinFailureReason.from(joinError: StubUnrelatedError()) == .unknown)
+    }
+}

--- a/ConvosTests/NewConversationViewModelJoinTelemetryTests.swift
+++ b/ConvosTests/NewConversationViewModelJoinTelemetryTests.swift
@@ -62,6 +62,32 @@ final class NewConversationViewModelJoinTelemetryTests: XCTestCase {
         XCTAssertEqual(fixtures.actions.startCount, 0)
     }
 
+    /// A join that succeeds on a retry must report the attempt it actually
+    /// was. `.ready` resets `consecutiveFailureCount` before the join task
+    /// reaches `handleJoinSuccess`, so deriving the number at outcome time
+    /// reported every successful retry as the first attempt.
+    func testSuccessfulRetryReportsItsRealAttemptNumber() async {
+        let fixtures = makeFixtures()
+
+        fixtures.viewModel.joinConversation(inviteCode: Constant.inviteCode)
+        fixtures.stateManager.setState(
+            .joinFailed(inviteTag: "tag", error: Self.expiredJoinError)
+        )
+        await waitFor { !fixtures.actions.joinOutcomes.isEmpty }
+        XCTAssertEqual(fixtures.actions.joinOutcomes.first?.attemptNumber, 1)
+
+        // The mock now carries the retry through to `.ready(origin: .joined)`,
+        // which is what resets the failure counter mid-flight.
+        fixtures.stateManager.autoCompletesActions = true
+        fixtures.viewModel.joinConversation(inviteCode: Constant.inviteCode)
+        await waitFor { fixtures.actions.joinOutcomes.contains { $0.isSuccess } }
+
+        let success = fixtures.actions.joinOutcomes.first { $0.isSuccess }
+        XCTAssertNotNil(success, "The retry must report a successful join")
+        XCTAssertEqual(success?.attemptNumber, 2,
+                       "A join that succeeded on the second try reports attempt 2, not 1")
+    }
+
     /// The funnel's denominator counts attempts, not calls into the join path.
     func testJoinAttemptIsReportedOncePerAttempt() async {
         let fixtures = makeFixtures()

--- a/ConvosTests/NewConversationViewModelJoinTelemetryTests.swift
+++ b/ConvosTests/NewConversationViewModelJoinTelemetryTests.swift
@@ -1,0 +1,236 @@
+import ConvosCore
+import ConvosInvites
+import ConvosMetrics
+import XCTest
+@testable import Convos
+
+/// Coverage for the join funnel's reporting invariants.
+///
+/// Instrumenting the failure paths introduced two ways to over-report that
+/// did not exist while those paths were silent: a wait window and a terminal
+/// callback can both fire for the same attempt, and `handleErrorState` serves
+/// conversation creation as well as joining. Both are pinned here.
+@MainActor
+final class NewConversationViewModelJoinTelemetryTests: XCTestCase {
+    /// A join that produces more than one terminal callback is still one
+    /// failed join. Without the latch, `.joinFailed` followed by `.error`
+    /// reports two failures for a single attempt.
+    func testASecondTerminalCallbackDoesNotReportAgain() async {
+        let fixtures = makeFixtures()
+        fixtures.viewModel.joinConversation(inviteCode: Constant.inviteCode)
+
+        fixtures.stateManager.setState(
+            .joinFailed(inviteTag: "tag", error: Self.expiredJoinError)
+        )
+        await waitFor { !fixtures.actions.joinOutcomes.isEmpty }
+
+        fixtures.stateManager.setState(.error(ConversationStateMachineError.timedOut))
+        await waitFor { fixtures.actions.joinOutcomes.count > 1 }
+
+        XCTAssertEqual(fixtures.actions.joinOutcomes.count, 1,
+                       "One attempt reports one failed joined_conversation, not one per callback")
+        XCTAssertEqual(fixtures.actions.joinOutcomes.first?.failureReason, .conversationExpired,
+                       "The first terminal cause is the one that is reported")
+    }
+
+    /// The creator's diagnostic string rides along so a `.genericFailure`
+    /// rejection is still diagnosable.
+    func testCreatorReasonIsReported() async {
+        let fixtures = makeFixtures()
+        fixtures.viewModel.joinConversation(inviteCode: Constant.inviteCode)
+
+        fixtures.stateManager.setState(
+            .joinFailed(inviteTag: "tag", error: Self.genericJoinError)
+        )
+        await waitFor { !fixtures.actions.joinOutcomes.isEmpty }
+
+        XCTAssertEqual(fixtures.actions.joinOutcomes.first?.failureReason, .unknown)
+        XCTAssertEqual(fixtures.actions.joinOutcomes.first?.creatorReason, "creator private key unavailable")
+    }
+
+    /// `handleErrorState` runs for conversation creation too. Only a join
+    /// stamps `verificationStartedAt`, and that stamp is what keeps creation
+    /// failures out of the join funnel.
+    func testCreationFailureIsNotReportedAsAJoin() async {
+        let fixtures = makeFixtures()
+
+        fixtures.stateManager.setState(.error(ConversationStateMachineError.timedOut))
+        await waitFor { !fixtures.actions.joinOutcomes.isEmpty }
+
+        XCTAssertTrue(fixtures.actions.joinOutcomes.isEmpty,
+                      "A failure with no join in flight is not a failed join")
+        XCTAssertEqual(fixtures.actions.startCount, 0)
+    }
+
+    /// The funnel's denominator counts attempts, not calls into the join path.
+    func testJoinAttemptIsReportedOncePerAttempt() async {
+        let fixtures = makeFixtures()
+        fixtures.viewModel.joinConversation(inviteCode: Constant.inviteCode)
+        await waitFor { fixtures.actions.startCount > 0 }
+
+        XCTAssertEqual(fixtures.actions.startCount, 1)
+    }
+
+    // MARK: - Fixtures
+
+    private struct Fixtures {
+        let viewModel: NewConversationViewModel
+        let stateManager: MockConversationStateManager
+        let actions: SpyCoreActions
+    }
+
+    private func makeFixtures() -> Fixtures {
+        let stateManager = MockConversationStateManager(
+            conversationId: Constant.stateManagerId,
+            draftConversationRepository: MockDraftConversationRepository(
+                conversation: .empty(id: Constant.stateManagerId)
+            )
+        )
+        stateManager.autoCompletesActions = false
+        let messagingService = MockMessagingService(conversationStateManager: stateManager)
+        let session = MockInboxesService(mockMessagingService: messagingService)
+        let actions = SpyCoreActions()
+        let viewModel = NewConversationViewModel(
+            session: session,
+            messagingService: messagingService,
+            coreActions: actions
+        )
+        return Fixtures(viewModel: viewModel, stateManager: stateManager, actions: actions)
+    }
+
+    private func waitFor(
+        timeout: TimeInterval = 2,
+        _ condition: () -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition(), Date() < deadline {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+    }
+
+    private static let expiredJoinError: InviteJoinError = InviteJoinError(
+        errorType: .conversationExpired,
+        inviteTag: "tag",
+        timestamp: Date()
+    )
+
+    private static let genericJoinError: InviteJoinError = InviteJoinError(
+        errorType: .genericFailure,
+        inviteTag: "tag",
+        timestamp: Date(),
+        reason: "creator private key unavailable"
+    )
+
+    private enum Constant {
+        static let stateManagerId: String = "join-telemetry-convo"
+        static let inviteCode: String = "abc123def456"
+    }
+}
+
+/// Records the join funnel calls. `NoOpCoreActions` is `final`, so the whole
+/// protocol is restated here; only the join members carry behavior.
+private final class SpyCoreActions: CoreActions, @unchecked Sendable {
+    struct JoinOutcome {
+        let isSuccess: Bool
+        let failureReason: JoinFailureReason?
+        let creatorReason: String?
+        let attemptNumber: Int
+    }
+
+    private let lock: NSLock = NSLock()
+    private var storedOutcomes: [JoinOutcome] = []
+    private var storedStartCount: Int = 0
+
+    var joinOutcomes: [JoinOutcome] {
+        lock.withLock { storedOutcomes }
+    }
+
+    var startCount: Int {
+        lock.withLock { storedStartCount }
+    }
+
+    func joinAttemptStarted(source: ConversationSource) async {
+        lock.withLock { storedStartCount += 1 }
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    func joinedConversation(
+        verificationDuration: Float,
+        memberCount: Int?,
+        hasAssistant: Bool?,
+        source: ConversationSource,
+        isSuccess: Bool,
+        failureReason: JoinFailureReason?,
+        creatorReason: String?,
+        attemptNumber: Int
+    ) async {
+        lock.withLock {
+            storedOutcomes.append(
+                JoinOutcome(
+                    isSuccess: isSuccess,
+                    failureReason: failureReason,
+                    creatorReason: creatorReason,
+                    attemptNumber: attemptNumber
+                )
+            )
+        }
+    }
+
+    func startedConversation() async {}
+    func invitedToConversation(memberCount: Int, hasAssistant: Bool, isSuccess: Bool) async {}
+    func addedAssistant(memberCount: Int) async {}
+    func assistantJoined(
+        waitDuration: Float,
+        source: AssistantJoinSource,
+        memberCount: Int?,
+        isSuccess: Bool
+    ) async {}
+    func assistantJoinRescuedByPolling(streamAgeSecs: Float, pollTick: Int) async {}
+    func sentMessage(
+        sendingTime: Float,
+        memberCount: Int,
+        attachmentTypes: [String],
+        hasText: Bool,
+        hasAssistant: Bool,
+        isSuccess: Bool
+    ) async {}
+    func sharedConversation(
+        memberCount: Int,
+        hasAssistant: Bool,
+        shareTarget: ShareTarget,
+        hasExpiration: Bool,
+        expiresAfterUse: Bool,
+        isSuccess: Bool
+    ) async {}
+    // swiftlint:disable:next function_parameter_count
+    func builtAgent(
+        buildDuration: Float,
+        instructionCharCount: Int,
+        instructionWordCount: Int,
+        attachmentTypes: [String],
+        hasVoiceMemo: Bool,
+        voiceMemoDuration: Float,
+        connectionTypes: [String],
+        entryMode: AgentBuilderEntryMode,
+        isSuccess: Bool,
+        fromPromptHint: Bool,
+        tapCount: Int
+    ) async {}
+    func promptHintTapped(tapCount: Int) async {}
+    func purchaseInitiated(
+        productId: String,
+        tier: ConvosMetrics.SubscriptionTier,
+        period: ConvosMetrics.SubscriptionPeriod,
+        source: ConvosMetrics.PaywallSource
+    ) async {}
+    func purchaseSucceeded(
+        productId: String,
+        tier: ConvosMetrics.SubscriptionTier,
+        period: ConvosMetrics.SubscriptionPeriod,
+        source: ConvosMetrics.PaywallSource,
+        durationSecs: Float
+    ) async {}
+    func purchaseCancelled(productId: String, source: ConvosMetrics.PaywallSource) async {}
+    func purchaseFailed(productId: String, source: ConvosMetrics.PaywallSource, reason: PurchaseFailureReason) async {}
+    func purchasesRestored(restoredCount: Int) async {}
+}


### PR DESCRIPTION
> **Unblocked.** [convos-shared#10](https://github.com/xmtplabs/convos-shared/pull/10) is merged; `ConvosCore/Package.swift` is back on `branch: "main"` and the temporary pin is gone (along with the older stale `mpr/web-plugins` pin it replaced). Ready to merge.

## Why

Every user who saw **"Couldn't join"** was invisible to analytics, and the stuck-in-**"Verifying"** shape most likely to be reported emitted nothing at all.

`joined_conversation`'s `is_success` was only ever set `false` by the client's 150s wait-window timer. The schema comment says so outright — it was designed to mean "the creator never approved." So explicit failures had no event, and timeouts had no cause attached.

Ten gaps, all closed here.

## Failure causes

- `handleJoinFailedState`, `handleErrorState` and `handleJoinError` all set `displayError` and returned without touching `coreActions`. They now emit through one `emitJoinFailure` helper.
- The helper cancels both wait windows unconditionally and clears `verificationStartedAt`. That makes an attempt report **exactly once**: a timer that already fired finds no stamp, and one still armed can no longer re-report the same failure later as a full-length stuck wait. Previously a user sitting on the error sheet for 150s emitted a bogus `is_success:false` with `verification_duration ≈ 150`.
- That same stamp keeps conversation *creation* failures out of the join funnel — `handleErrorState` serves both paths and only a join sets it.
- `JoinFailureReason+Mapping` carries the three existing taxonomies into the event: `ConversationStateMachineError`, its `NetworkErrorKind`, and the creator's `InviteJoinErrorType`. **Network classification is checked first**, because `.stateMachineError` wraps the transport error the kind is matched from — checking the case first would collapse every network failure into `.unknown`. Pinned by tests.
- `InviteJoinError.reason` — documented as telemetry-bound since it was added, but until now only interpolated into a device-local `Log.info` — rides along as `creator_reason`.

## The silent "Verifying" paths

- `joinConversation` stamped `verificationStartedAt` then returned **before** `armJoinTimeout()` when the inbox wasn't ready, parking the code in `pendingInviteCode`. If the replay never came, the user watched "Verifying" forever and nothing fired — not even the timeout. That branch now arms its own window and reports `inbox_never_ready`.
- The replay is marked `isReplay` so it neither double-counts the attempt nor restarts the clock on time already waited.
- `ConversationViewModel`'s drawer "Verifying" had no timer and no telemetry at all. It now measures the wait too, and only arms for a conversation already pending at init — a live join starts from a draft and is measured by `NewConversationViewModel`, so the two can't report the same wait.

## Funnel ends

- `join_attempt_started` gives the funnel a denominator. A start with no matching outcome is itself the signal that a join was dropped silently.
- `sharedConversation` was fully implemented and called from **nowhere**, so invite distribution went unmeasured. All five invite share surfaces route through the same `shareSheet` modifier and now report through `ConversationShareReporter`, including cancelled shares.
- `InviteWriter`'s mint failure reached nothing but a `Log.warning`.

## Sentry

The existing `assistant_join_rescued_by_polling` bridge now also forwards failed joins — but only the causes that mean something is broken on our side (`inbox_never_ready`, `signature_verification_failed`, `internal_storage_error`, `unknown`). An unapproved invite, an expired convo or a dropped connection are expected outcomes with real volume; they belong in the funnel, not an issue tracker. The message doubles as the grouping key so each cause gets its own issue.

## Dependency

`ConvosCore/Package.swift` is pinned to the convos-shared PR branch. That branch is cut from `mpr/web-plugins` rather than `main` **deliberately**: `main`'s `ChatPlugin` gained `showAgentDm()`, which `HomeChatPlugin` has not adopted, so pinning `main` fails to build for reasons unrelated to this change. Adopting that bridge method is separate work and is not in scope here.

This replaces the existing stale `mpr/web-plugins` pin (that branch is already merged to `main`).

## Notes for review

- `invited_to_conversation` reports `member_count: 0` on failure because the schema's fields are non-optional; `is_success` disambiguates. Its descriptor comment now also spells out that it means invite *creation* during setup, not a user sharing one — the name has misled before. Renaming it would break existing dashboards, so that's left as a separate call for whoever owns them.
- The drawer surface reports `source: .url` because the original entry point isn't persisted on the conversation; `failure_reason` is the load-bearing dimension there, not `source`.
- Also fixes a doc comment referencing `conversation_join_timed_out`, an event removed when the join funnels were unified — any dashboard keyed on that name reports zero.

## Verification

- `swift test --package-path ConvosCore` — **2068 tests in 272 suites passed**
- `xcodebuild test -only-testing:ConvosTests/NewConversationViewModelRetryTests` — **TEST SUCCEEDED**
- `xcodebuild build -scheme "Convos (Dev)" -configuration Dev` — **BUILD SUCCEEDED**, no type-check-time warnings
- `swiftlint` — 0 violations; `swiftformat` — no changes
- New `JoinFailureReasonMappingTests` covers all three taxonomies, the network-precedence ordering, and the unclassifiable fallbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790271639&installation_model_id=20076&pr_number=1429&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1429&signature=d737d3b1fbc9b6904c735fd996c4f99210d56999726283c36d9afc96bb1a3cd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Instrument invite sharing, join attempts, and join failures with metrics
> - Join flow in `NewConversationViewModel` now reports `join_attempt_started` once per attempt and a terminal `joined_conversation` metric (success or failure) with classified `failureReason`, `creatorReason`, and `attemptNumber`; a new inbox readiness timeout reports stuck 'Verifying' states as `inboxNeverReady` failures
> - New `ConversationShareReporter` centralizes `shared_conversation` reporting from all invite share surfaces (contacts, conversation info, members list, in-conversation), capturing share target and completion outcome
> - `InviteWriter.generate` now reports `invited_to_conversation` for both success and failure cases; new `JoinFailureReason+Mapping` maps `InviteJoinErrorType`, `ConversationStateMachineError`, and network errors onto a unified `JoinFailureReason`
> - `PostHogCollector` forwards selected join failure reasons to Sentry as warning events; web home plugin gains a `showAgentDm` bridge handler that programmatically switches the conversation view to the Agent tab
> - Risk: `NoOpCoreActions` protocol signatures for `joinedConversation` and `invitedToConversation` are expanded with new fields (`failureReason`, `creatorReason`, `attemptNumber`, `isSuccess`); out-of-tree `CoreActions` conformers must update these methods
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1416efa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

---

## Review round 1 (Macroscope) — three findings, all fixed in `52023c72`

Macroscope found three real over/under-reporting bugs. All are fixed, and two of them invalidated a claim the original description made.

**1. An attempt could report two failures.** The original write-up said the emit helper "fires exactly once per attempt." That was wrong for one ordering: `emitConversationJoinTimedOut` deliberately leaves `verificationStartedAt` set so a late approval can still report success, which meant an approval timeout at 150s followed by a `.joinFailed` from the creator emitted *two* failed outcomes for one attempt. There is now an explicit `joinFailureReported` latch: an attempt reports at most one failure however many terminal callbacks it produces, while a late success after a timeout still reports (that pairing is intentional and unchanged).

**2. A late replay produced an unmatched outcome.** If inbox acquisition completed *after* the inbox-readiness window elapsed, the `isReplay` call reset `verificationStartedAt` and later reported success or failure with no matching `join_attempt_started`, at a duration measured from the replay rather than from anything the user experienced. A replay now only continues the parked attempt while that attempt is still open (`continuesParkedAttempt`); one that lands after the outcome was reported is started and counted as a fresh attempt.

**3. `InviteWriter` had uninstrumented exits.** `identityStore.load()` throwing or returning nil, and a failing preflight invite delete, all exited before the instrumented `do`/`catch`. Those paths are now inside it, and every throwing exit reports through `reportInviteCreationFailed()`.

### New regression coverage

`NewConversationViewModelJoinTelemetryTests` pins the invariants with a spy `CoreActions`:

- a second terminal callback after the first does not report again (the finding-1 latch)
- `creator_reason` is carried through on a `.genericFailure` rejection
- a creation failure with no join in flight is not reported as a failed join
- `join_attempt_started` reports once per attempt

The double-report test is non-vacuous: `MockConversationStateManager.setState` yields unconditionally, so the second state genuinely reaches `handleErrorState` and only the latch prevents the second emit.

### Review round 2 — attempt numbering (`a6ccdf6c`)

One more real bug: `.ready` resets `consecutiveFailureCount` before the join task reaches `handleJoinSuccess`, so every join that succeeded on a retry reported `attempt_number: 1` — the one number the retry breakdown exists to answer. The attempt number is now captured when the attempt starts and read back at every outcome, which also retires the two different derivations the failure paths were using (some sites had already incremented the counter, some had not); `emitJoinFailure` no longer takes it as a parameter.

`testSuccessfulRetryReportsItsRealAttemptNumber` drives a failure, then a retry the mock carries through to `.ready(origin: .joined)`, and asserts the success reports attempt 2.



### Pin flip (`1416efa5`)

`convos-shared` is pinned back to `main`. Doing that required adopting `ChatPlugin.showAgentDm()`, which landed in convos-shared#8 with no iOS implementation — `HomeChatPlugin` did not conform, so pinning `main` failed to build for reasons unrelated to telemetry. It is wired to the same destination the member card's agent action opens (`selectTab(.agent)`), so the web surface and the native one agree on what "the agent DM" is.

The merged `ConvosMetrics` and descriptors are byte-identical to the branch the ConvosCore suite was run against (`git diff 3197e82 origin/main -- ConvosMetrics` is empty), so that 2068-test run still covers this dependency. The app targets were rebuilt and retested against `main`.
