### PR TITLE
chore(renovate): sort the unified pre.* prerelease timeline

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Match the libxmtp tag in Package.swift `revision:` pins. Recognizes both -dev and -nightly tags as currentValue; allowedVersions in the package rule restricts update candidates to nightly only.",
+      "description": "Match the libxmtp tag in Package.swift `revision:` pins. Recognizes the unified `pre.<YYYYMMDDHHMM>.<channel>.<sha>` timeline as well as legacy -dev and -nightly tags as currentValue; allowedVersions in the package rule restricts update candidates to the pre. timeline plus legacy nightlies during the transition.",
       "managerFilePatterns": [
         "/Package\\.swift$/"
       ],
@@ -25,11 +25,11 @@
       ],
       "datasourceTemplate": "git-tags",
       "depNameTemplate": "https://github.com/xmtp/libxmtp",
-      "versioningTemplate": "regex:^ios-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?:dev|nightly)\\.(?<build>\\d{8}\\.[a-f0-9]+|[a-f0-9]+)$"
+      "versioningTemplate": "regex:^ios-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?:pre\\.(?<build>\\d{12})\\.(?:dev|nightly)\\.[a-f0-9]+|(?:dev|nightly)\\.(?:\\d{8}\\.)?[a-f0-9]+)$"
     },
     {
       "customType": "regex",
-      "description": "Match Package.resolved's libxmtp entry. SPM stores the tag under `branch` and the resolved commit SHA under `revision`; both must be updated together, captured here as currentValue + currentDigest.",
+      "description": "Match Package.resolved's libxmtp entry. SPM stores the tag under `branch` and the resolved commit SHA under `revision`; both must be updated together, captured here as currentValue + currentDigest. Versioning parses the unified `pre.<YYYYMMDDHHMM>.<channel>.<sha>` timeline alongside legacy -dev and -nightly tags.",
       "managerFilePatterns": [
         "/Package\\.resolved$/"
       ],
@@ -38,7 +38,7 @@
       ],
       "datasourceTemplate": "git-tags",
       "depNameTemplate": "https://github.com/xmtp/libxmtp",
-      "versioningTemplate": "regex:^ios-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?:dev|nightly)\\.(?<build>\\d{8}\\.[a-f0-9]+|[a-f0-9]+)$"
+      "versioningTemplate": "regex:^ios-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?:pre\\.(?<build>\\d{12})\\.(?:dev|nightly)\\.[a-f0-9]+|(?:dev|nightly)\\.(?:\\d{8}\\.)?[a-f0-9]+)$"
     }
   ],
   "packageRules": [
@@ -72,7 +72,7 @@
       "prConcurrentLimit": 1,
       "prCreation": "immediate",
       "rebaseWhen": "behind-base-branch",
-      "allowedVersions": "/^ios-\\d+\\.\\d+\\.\\d+-nightly\\.\\d{8}\\.[a-f0-9]+$/",
+      "allowedVersions": "/^ios-\\d+\\.\\d+\\.\\d+-(?:pre\\.\\d{12}\\.(?:dev|nightly)\\.[a-f0-9]+|nightly\\.\\d{8}\\.[a-f0-9]+)$/",
       "commitMessageTopic": "libxmtp",
       "commitMessageExtra": "to {{newValue}}"
     },

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Match the libxmtp tag in Package.swift `revision:` pins. Recognizes the unified `pre.<YYYYMMDDHHMM>.<channel>.<sha>` timeline as well as legacy -dev and -nightly tags as currentValue; allowedVersions in the package rule restricts update candidates to the pre. timeline plus legacy nightlies during the transition.",
+      "description": "Match the libxmtp tag in Package.swift `revision:` pins. Recognizes the unified `pre.<YYYYMMDDHHMMSS>.<channel>.<sha>` timeline as well as legacy -dev and -nightly tags as currentValue; allowedVersions in the package rule restricts update candidates to the pre. timeline plus legacy nightlies during the transition.",
       "managerFilePatterns": [
         "/Package\\.swift$/"
       ],
@@ -25,11 +25,11 @@
       ],
       "datasourceTemplate": "git-tags",
       "depNameTemplate": "https://github.com/xmtp/libxmtp",
-      "versioningTemplate": "regex:^ios-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?:pre\\.(?<build>\\d{12})\\.(?:dev|nightly)\\.[a-f0-9]+|(?:dev|nightly)\\.(?:\\d{8}\\.)?[a-f0-9]+)$"
+      "versioningTemplate": "regex:^ios-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?:pre\\.(?<build>\\d{14})\\.(?:dev|nightly)\\.[a-f0-9]+|(?:dev|nightly)\\.(?:\\d{8}\\.)?[a-f0-9]+)$"
     },
     {
       "customType": "regex",
-      "description": "Match Package.resolved's libxmtp entry. SPM stores the tag under `branch` and the resolved commit SHA under `revision`; both must be updated together, captured here as currentValue + currentDigest. Versioning parses the unified `pre.<YYYYMMDDHHMM>.<channel>.<sha>` timeline alongside legacy -dev and -nightly tags.",
+      "description": "Match Package.resolved's libxmtp entry. SPM stores the tag under `branch` and the resolved commit SHA under `revision`; both must be updated together, captured here as currentValue + currentDigest. Versioning parses the unified `pre.<YYYYMMDDHHMMSS>.<channel>.<sha>` timeline alongside legacy -dev and -nightly tags.",
       "managerFilePatterns": [
         "/Package\\.resolved$/"
       ],
@@ -38,7 +38,7 @@
       ],
       "datasourceTemplate": "git-tags",
       "depNameTemplate": "https://github.com/xmtp/libxmtp",
-      "versioningTemplate": "regex:^ios-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?:pre\\.(?<build>\\d{12})\\.(?:dev|nightly)\\.[a-f0-9]+|(?:dev|nightly)\\.(?:\\d{8}\\.)?[a-f0-9]+)$"
+      "versioningTemplate": "regex:^ios-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?:pre\\.(?<build>\\d{14})\\.(?:dev|nightly)\\.[a-f0-9]+|(?:dev|nightly)\\.(?:\\d{8}\\.)?[a-f0-9]+)$"
     }
   ],
   "packageRules": [
@@ -72,7 +72,7 @@
       "prConcurrentLimit": 1,
       "prCreation": "immediate",
       "rebaseWhen": "behind-base-branch",
-      "allowedVersions": "/^ios-\\d+\\.\\d+\\.\\d+-(?:pre\\.\\d{12}\\.(?:dev|nightly)\\.[a-f0-9]+|nightly\\.\\d{8}\\.[a-f0-9]+)$/",
+      "allowedVersions": "/^ios-\\d+\\.\\d+\\.\\d+-(?:pre\\.\\d{14}\\.(?:dev|nightly)\\.[a-f0-9]+|nightly\\.\\d{8}\\.[a-f0-9]+)$/",
       "commitMessageTopic": "libxmtp",
       "commitMessageExtra": "to {{newValue}}"
     },


### PR DESCRIPTION
xmtp/libxmtp#4048 collapses main-cut dev and nightly prereleases into one semver-ordered format:

```
ios-X.Y.Z-pre.<YYYYMMDDHHMMSS>.<channel>.<shortSha>     channel ∈ {dev, nightly}
```

Both channels now publish onto a **single timeline**. This PR teaches our renovate config to sort that timeline.

### What changes

- Both `customManagers` entries (`Package.swift` and `Package.resolved`) get the same widened `versioningTemplate`, capturing the 14-digit UTC timestamp as the `build` group:

  ```
  regex:^ios-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-(?:pre\.(?<build>\d{14})\.(?:dev|nightly)\.[a-f0-9]+|(?:dev|nightly)\.(?:\d{8}\.)?[a-f0-9]+)$
  ```

- The libxmtp `packageRules` entry widens `allowedVersions` to admit the new shape while legacy nightlies stay admitted:

  ```
  /^ios-\d+\.\d+\.\d+-(?:pre\.\d{14}\.(?:dev|nightly)\.[a-f0-9]+|nightly\.\d{8}\.[a-f0-9]+)$/
  ```

- Both manager `description`s now say so. `matchStrings` are unchanged — they were already shape-agnostic.

### Ordering is by timestamp; channel is metadata

Within an `X.Y.Z`, the only thing renovate compares is the `build` group — the second-precision UTC timestamp of the publish. `dev` vs `nightly` is trailing metadata that no longer participates in ordering, so "the newest libxmtp main build" is simply "the largest timestamp", whichever channel produced it.

### Legacy shapes parse but sort below (transition bridge)

The `(?:dev|nightly)\.(?:\d{8}\.)?[a-f0-9]+` alternative keeps the old tags parseable, but it deliberately captures **no `build` group**. A version with an absent `build` sorts below any `pre.*` of the same `X.Y.Z`. Consequences, all intended:

- A pin currently sitting on a legacy `ios-X.Y.Z-nightly.<date>.<sha>` stays valid and upgradable — the first `pre.*` cut of that `X.Y.Z` compares greater and wins, with no manual re-pin.
- Legacy pins stay parseable and upgrade cleanly onto the first `pre.*` version, but legacy→legacy nightly bumps *within* one `X.Y.Z` pause until then: with no `build` group captured, two legacy nightlies of the same `X.Y.Z` compare equal, so renovate has no upgrade to offer between them. Merging after xmtp/libxmtp#4048 publishes its first `pre.*` tag therefore shrinks that stall window. `allowedVersions` retaining legacy nightlies still covers a cross-`X.Y.Z` move off the current pin.
- Legacy branch-cut `dev.<sha>` tags parse but stay out of `allowedVersions`, exactly as before.

### Dev supersession is the policy

Because both channels share the timeline, a newer publish of *either* channel supersedes an older `dev` pin. That is deliberate: a dev build is a point-in-time snapshot of main, and once main has moved, the newer build is the one we want. There is no per-channel "stickiness" and none is wanted.

Depends on xmtp/libxmtp#4048 landing for the new tags to exist; this config is a no-op until then and safe to merge at any point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790284610&installation_model_id=20076&pr_number=1432&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1432&signature=fe3afb0694b0bc2fae73a4c053e0715b328e4208cc9da9d56d960a267422205f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `renovate.json` to sort and support unified `pre.<timestamp>.<channel>.<sha>` prerelease tags
> - Updates description fields and versioning regexes in [renovate.json](https://github.com/xmtplabs/convos-ios/pull/1432/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57) to parse the new unified `pre.<14-digit timestamp>.(dev|nightly).<sha>` format alongside legacy `-dev` and `-nightly` tags.
> - Adjusts `allowedVersions` so update candidates are limited to unified `pre.(dev|nightly)` tags and legacy `nightly` tags; legacy `dev`-only tags are excluded.
> - Risk: legacy `dev`-only tags no longer qualify as update candidates, which may cause Renovate to skip some previously eligible updates for libxmtp matchers in `Package.swift` and `Package.resolved`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a8945e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
