### PR TITLE
feat(conversations): add Open Agent DM / Open Things context-menu items

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -36,6 +36,11 @@ struct ConversationView<MessagesBottomBar: View>: View {
     /// DM page instead of the group. Used when a conversations-list row is
     /// tapped whose most-recent unread is in the DM.
     var initialAgentDmInboxId: String?
+    /// An explicit page to open on, overriding the unread heuristic. Set by the
+    /// list's "Open Agent DM" / "Open Things" context-menu actions so the open
+    /// lands on the chosen tab regardless of which lane holds the unread. Nil
+    /// leaves the heuristic in charge.
+    var initialTabOverride: ConversationTab?
     /// Controls the messages list's leading empty-state view (QR invite +
     /// identity, or the `ConversationInfoPreview`). Defaults to `.standard`
     /// in normal chat. The Agent Builder passes `.hidden` so the
@@ -366,13 +371,18 @@ struct ConversationView<MessagesBottomBar: View>: View {
     private func seedInitialTabIfNeeded() {
         guard !didSeedInitialTab else { return }
         didSeedInitialTab = true
-        let agentDmRequested: Bool = initialAgentDmInboxId != nil
-            && initialAgentDmInboxId == primaryAgentInboxId
-        let tab: ConversationTab = ConversationTab.initial(
-            available: availableTabs,
-            agentDmRequested: agentDmRequested,
-            agentDmHoldsTheUnread: agentDmHoldsTheUnread
-        )
+        let tab: ConversationTab
+        if let override = initialTabOverride, availableTabs.contains(override) {
+            tab = override
+        } else {
+            let agentDmRequested: Bool = initialAgentDmInboxId != nil
+                && initialAgentDmInboxId == primaryAgentInboxId
+            tab = ConversationTab.initial(
+                available: availableTabs,
+                agentDmRequested: agentDmRequested,
+                agentDmHoldsTheUnread: agentDmHoldsTheUnread
+            )
+        }
         guard tab != selectedTab else { return }
         selectTab(tab)
     }
@@ -1401,29 +1411,66 @@ private extension ConversationView {
     /// so a Space page is not reloaded every time the user looks away.
     @ViewBuilder
     var pageHost: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 0) {
-                ForEach(availableTabs) { tab in
-                    page(for: tab)
-                        // Sized against the scroll view's container rather than
-                        // a `GeometryReader`: the reader measures zero on the
-                        // first layout pass, which left every page zero-width
-                        // and the pager resting on the last one instead of the
-                        // tab the conversation opened on.
-                        .containerRelativeFrame(.horizontal)
-                        .id(tab)
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 0) {
+                    ForEach(availableTabs) { tab in
+                        page(for: tab)
+                            // Sized against the scroll view's container rather than
+                            // a `GeometryReader`: the reader measures zero on the
+                            // first layout pass, which left every page zero-width
+                            // and the pager resting on the last one instead of the
+                            // tab the conversation opened on.
+                            .containerRelativeFrame(.horizontal)
+                            .id(tab)
+                    }
+                }
+                .scrollTargetLayout()
+            }
+            .scrollTargetBehavior(.paging)
+            .scrollPosition(id: pagerSelection)
+            // A long-press menu owns the screen while it is up, and a drag that
+            // paged out from under it would leave the menu pointing at a message
+            // on another tab.
+            .scrollDisabled(isPagingDisabled)
+            .introspect(.scrollView, on: .iOS(.v26)) { (scrollView: UIScrollView) in
+                scrollView.bounces = false
+            }
+            .onChange(of: didSeedInitialTab, initial: false) { _, seeded in
+                guard seeded else { return }
+                realignPagerAfterSeeding(using: proxy)
+            }
+        }
+    }
+
+    /// Snaps the pager onto the seeded tab once the scroll view has laid out.
+    ///
+    /// Seeding sets `selectedTab` in `onAppear`, before the pager finishes its
+    /// first layout, so `scrollPosition` scrolls toward the target while paging
+    /// is still settling. A tab two pages from the default (Things sits past
+    /// Agent) can settle the pager on the page in between while the state still
+    /// reads the target - the segmented control shows the seeded tab but the
+    /// wrong page is on screen. Re-driving the offset once through the scroll
+    /// proxy, after this layout pass, lands the page the state already points at.
+    private func realignPagerAfterSeeding(using proxy: ScrollViewProxy) {
+        let target: ConversationTab = selectedTab
+        guard target != .group else { return }
+        // The pager's container measures zero on its first layout pass, so the
+        // seed's `scrollPosition` can settle on an intermediate page (Things sits
+        // past Agent), and the Space page finishes laying out a beat later still.
+        // Re-assert the offset across the next few frames until the late layout
+        // has caught up; once the pager is on the target the scroll is a no-op,
+        // and the guard leaves a user who swiped away in that window alone.
+        let delays: [Double] = [0, 0.1, 0.2, 0.35, 0.5, 0.75]
+        for delay in delays {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                guard selectedTab == target else { return }
+                var transaction = Transaction()
+                transaction.disablesAnimations = true
+                withTransaction(transaction) {
+                    proxy.scrollTo(target, anchor: .leading)
                 }
             }
-            .scrollTargetLayout()
-        }
-        .scrollTargetBehavior(.paging)
-        .scrollPosition(id: pagerSelection)
-        // A long-press menu owns the screen while it is up, and a drag that
-        // paged out from under it would leave the menu pointing at a message
-        // on another tab.
-        .scrollDisabled(isPagingDisabled)
-        .introspect(.scrollView, on: .iOS(.v26)) { (scrollView: UIScrollView) in
-            scrollView.bounces = false
         }
     }
 

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -420,6 +420,22 @@ struct ConversationView<MessagesBottomBar: View>: View {
         selectTab(.agent)
     }
 
+    /// Switches to a requested tab when the list's "Open Agent DM" / "Open Things"
+    /// action targets this conversation while it is already on screen (a fresh
+    /// open seeds the tab from `initialTabOverride`, but reselecting the same
+    /// conversation is a no-op, so a mounted view has to be told directly).
+    /// Ignores requests for another conversation or a tab this one doesn't offer.
+    private func handleSelectConversationTabRequest(_ note: Notification) {
+        guard let conversationId = note.userInfo?["conversationId"] as? String,
+              conversationId == viewModel.conversation.id,
+              let rawTab = note.userInfo?["tab"] as? String,
+              let tab = ConversationTab(rawValue: rawTab),
+              availableTabs.contains(tab) else {
+            return
+        }
+        selectTab(tab)
+    }
+
     /// Programmatic tab selection. Every page is mounted, so this is only the
     /// write - `onChange(of: selectedTab)` does the rest for taps and swipes
     /// alike.
@@ -593,6 +609,9 @@ struct ConversationView<MessagesBottomBar: View>: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .selectAgentDmPageRequested)) { note in
             handleSelectAgentDmPageRequest(note)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .selectConversationTabRequested)) { note in
+            handleSelectConversationTabRequest(note)
         }
         .onReceive(NotificationCenter.default.publisher(for: .conversationNotificationTapped)) { notification in
             let conversationId: String? = notification.userInfo?["conversationId"] as? String

--- a/Convos/Conversations List/ConversationContextMenuContent.swift
+++ b/Convos/Conversations List/ConversationContextMenuContent.swift
@@ -11,6 +11,22 @@ func conversationContextMenuContent(
 ) -> some View {
     let isPending = conversation.isPendingInvite
 
+    if !isPending && conversation.hasHadVerifiedAgent {
+        ControlGroup {
+            let openAgentDmAction = { viewModel.selectAgentDm(conversation) }
+            Button(action: openAgentDmAction) {
+                Label("Agent", systemImage: "a.circle.fill")
+            }
+            .accessibilityIdentifier("context-menu-open-agent-dm")
+
+            let openThingsAction = { viewModel.selectThings(conversation) }
+            Button(action: openThingsAction) {
+                Label("Things", systemImage: "square.grid.2x2.fill")
+            }
+            .accessibilityIdentifier("context-menu-open-things")
+        }
+    }
+
     if !isPending {
         ControlGroup {
             let togglePinAction = { viewModel.togglePin(conversation: conversation) }
@@ -38,20 +54,6 @@ func conversationContextMenuContent(
             }
         }
         .accessibilityIdentifier("context-menu-pin")
-    }
-
-    if !isPending && conversation.hasHadVerifiedAgent {
-        let openAgentDmAction = { viewModel.selectAgentDm(conversation) }
-        Button(action: openAgentDmAction) {
-            Label("Open Agent DM", systemImage: "person.bubble")
-        }
-        .accessibilityIdentifier("context-menu-open-agent-dm")
-
-        let openThingsAction = { viewModel.selectThings(conversation) }
-        Button(action: openThingsAction) {
-            Label("Open Things", systemImage: "square.grid.2x2")
-        }
-        .accessibilityIdentifier("context-menu-open-things")
     }
 
     if !isPending && conversation.creator.isCurrentUser {

--- a/Convos/Conversations List/ConversationContextMenuContent.swift
+++ b/Convos/Conversations List/ConversationContextMenuContent.swift
@@ -40,6 +40,20 @@ func conversationContextMenuContent(
         .accessibilityIdentifier("context-menu-pin")
     }
 
+    if !isPending && conversation.hasHadVerifiedAgent {
+        let openAgentDmAction = { viewModel.selectAgentDm(conversation) }
+        Button(action: openAgentDmAction) {
+            Label("Open Agent DM", systemImage: "person.bubble")
+        }
+        .accessibilityIdentifier("context-menu-open-agent-dm")
+
+        let openThingsAction = { viewModel.selectThings(conversation) }
+        Button(action: openThingsAction) {
+            Label("Open Things", systemImage: "square.grid.2x2")
+        }
+        .accessibilityIdentifier("context-menu-open-things")
+    }
+
     if !isPending && conversation.creator.isCurrentUser {
         Button(action: onExplode) {
             Text("Explode")

--- a/Convos/Conversations List/ConversationContextMenuContent.swift
+++ b/Convos/Conversations List/ConversationContextMenuContent.swift
@@ -15,13 +15,13 @@ func conversationContextMenuContent(
         ControlGroup {
             let openAgentDmAction = { viewModel.selectAgentDm(conversation) }
             Button(action: openAgentDmAction) {
-                Label("Agent", systemImage: "a.circle.fill")
+                Label("Agent", systemImage: "a.circle")
             }
             .accessibilityIdentifier("context-menu-open-agent-dm")
 
             let openThingsAction = { viewModel.selectThings(conversation) }
             Button(action: openThingsAction) {
-                Label("Things", systemImage: "square.grid.2x2.fill")
+                Label("Things", systemImage: "square.grid.2x2")
             }
             .accessibilityIdentifier("context-menu-open-things")
         }
@@ -33,7 +33,7 @@ func conversationContextMenuContent(
             Button(action: togglePinAction) {
                 Label(
                     conversation.isPinned ? "Unfav" : "Fav",
-                    systemImage: conversation.isPinned ? "star.slash.fill" : "star.fill"
+                    systemImage: conversation.isPinned ? "star.slash" : "star"
                 )
             }
 
@@ -41,7 +41,7 @@ func conversationContextMenuContent(
             Button(action: toggleReadAction) {
                 Label(
                     conversation.isUnread ? "Read" : "Unread",
-                    systemImage: conversation.isUnread ? "checkmark.message.fill" : "message.badge.fill"
+                    systemImage: conversation.isUnread ? "checkmark.message" : "message.badge"
                 )
             }
 
@@ -49,7 +49,7 @@ func conversationContextMenuContent(
             Button(action: toggleMuteAction) {
                 Label(
                     conversation.isMuted ? "Unmute" : "Mute",
-                    systemImage: conversation.isMuted ? "bell.fill" : "bell.slash.fill"
+                    systemImage: conversation.isMuted ? "bell" : "bell.slash"
                 )
             }
         }

--- a/Convos/Conversations List/ConversationsView.swift
+++ b/Convos/Conversations List/ConversationsView.swift
@@ -168,6 +168,7 @@ struct ConversationsView: View {
                 messagesTextFieldEnabled: !convoVM.conversation.isPendingInvite,
                 isReadOnly: isReadOnly,
                 initialAgentDmInboxId: viewModel.selectedInitialAgentDmInboxId,
+                initialTabOverride: viewModel.selectedInitialTab,
                 bottomBarContent: { EmptyView() }
             )
         }
@@ -235,6 +236,12 @@ struct ConversationsView: View {
             isBootSettled: viewModel.bootSettlement.isSettled,
             onSelectConversation: { conversation in
                 viewModel.select(conversation)
+            },
+            onOpenAgentDm: { conversation in
+                viewModel.selectAgentDm(conversation)
+            },
+            onOpenThings: { conversation in
+                viewModel.selectThings(conversation)
             },
             onConfirmedDeleteConversation: { conversation in
                 viewModel.leave(conversation: conversation)

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -147,8 +147,17 @@ final class ConversationsViewModel {
                 }
             }
         } else {
-            if opensGroupTab, let previousViewModel = selectedConversationViewModel {
-                markConversationAsRead(previousViewModel.conversation)
+            if let previousViewModel = selectedConversationViewModel {
+                if opensGroupTab {
+                    markConversationAsRead(previousViewModel.conversation)
+                }
+                // A real open session is ending: reset the per-open tab overrides
+                // so a closed Agent-DM/Things session can't leave its intent on the
+                // view model. Gated on an actual view model (not just a nil id) so a
+                // select() whose conversation isn't in the loaded page yet - which
+                // also lands here - keeps the intent it just set for the pushed view.
+                selectedInitialTab = nil
+                selectedInitialAgentDmInboxId = nil
             }
             updateSelectionTask?.cancel()
             selectedConversationViewModel = nil

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -126,6 +126,12 @@ final class ConversationsViewModel {
     private func updateSelectionState() {
         let conversation = selectedConversation
         let previousViewModelId = selectedConversationViewModel?.conversation.id
+        // An explicit Agent-DM or Things opening (selectedInitialTab set) must not
+        // clear the Group lane's unread - neither on open nor when the session ends.
+        // Only the Group tab actually showing marks the group read, via the detail
+        // view's read-lane machinery. The normal tap path leaves selectedInitialTab
+        // nil and keeps marking the group read here.
+        let opensGroupTab: Bool = selectedInitialTab == nil
 
         if let conversation = conversation {
             if selectedConversationViewModel?.conversation.id != conversation.id {
@@ -136,10 +142,12 @@ final class ConversationsViewModel {
                     coreActions: coreActions
                 )
                 selectedConversationViewModel = viewModel
-                markConversationAsRead(conversation)
+                if opensGroupTab {
+                    markConversationAsRead(conversation)
+                }
             }
         } else {
-            if let previousViewModel = selectedConversationViewModel {
+            if opensGroupTab, let previousViewModel = selectedConversationViewModel {
                 markConversationAsRead(previousViewModel.conversation)
             }
             updateSelectionTask?.cancel()

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -59,6 +59,12 @@ final class ConversationsViewModel {
     /// the destination builder; nil means open on the group page.
     private(set) var selectedInitialAgentDmInboxId: String?
 
+    /// An explicit page to open the pushed conversation on, set when a
+    /// context-menu action ("Open Agent DM" / "Open Things") picks the page
+    /// directly instead of letting the unread heuristic choose. Read by the
+    /// destination builder; nil for a normal tap, where the heuristic decides.
+    private(set) var selectedInitialTab: ConversationTab?
+
     @ObservationIgnored
     private var updateSelectionTask: Task<Void, Never>?
 
@@ -66,7 +72,27 @@ final class ConversationsViewModel {
     /// agent-DM page when the most-recent unread message lives in the DM (and to
     /// the group otherwise).
     func select(_ conversation: Conversation) {
+        selectedInitialTab = nil
         selectedInitialAgentDmInboxId = agentDmInboxIdForMostRecentUnread(in: conversation)
+        selectedConversationId = conversation.id
+    }
+
+    /// Selects a conversation and opens it on the agent's DM page, regardless of
+    /// which lane holds the most-recent unread. Backs the "Open Agent DM"
+    /// context-menu action. The `.agent` tab override drives the open on its own,
+    /// so this does not depend on the volatile folded-in `agentDm` summary; the
+    /// Agent tab resolves its DM from the conversation's own members.
+    func selectAgentDm(_ conversation: Conversation) {
+        selectedInitialTab = .agent
+        selectedInitialAgentDmInboxId = nil
+        selectedConversationId = conversation.id
+    }
+
+    /// Selects a conversation and opens it on the Things (Space) page. Backs the
+    /// "Open Things" context-menu action.
+    func selectThings(_ conversation: Conversation) {
+        selectedInitialTab = .context
+        selectedInitialAgentDmInboxId = nil
         selectedConversationId = conversation.id
     }
 
@@ -780,6 +806,7 @@ final class ConversationsViewModel {
         if conversationInPage(id: id) == nil {
             outOfWindowSelectedConversation = conversation
         }
+        selectedInitialTab = nil
         selectedInitialAgentDmInboxId = nil
         selectedConversationId = id
         return true
@@ -1677,6 +1704,7 @@ extension ConversationsViewModel {
             }
             // Seeds the DM page when the parent opens fresh (or from a different
             // conversation)...
+            selectedInitialTab = nil
             selectedInitialAgentDmInboxId = routing.agentInboxId
             selectedConversationId = routing.originConversationId
             // ...and switches the page when the parent is already on screen (where

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -86,6 +86,7 @@ final class ConversationsViewModel {
         selectedInitialTab = .agent
         selectedInitialAgentDmInboxId = nil
         selectedConversationId = conversation.id
+        requestTab(.agent, for: conversation.id)
     }
 
     /// Selects a conversation and opens it on the Things (Space) page. Backs the
@@ -94,6 +95,22 @@ final class ConversationsViewModel {
         selectedInitialTab = .context
         selectedInitialAgentDmInboxId = nil
         selectedConversationId = conversation.id
+        requestTab(.context, for: conversation.id)
+    }
+
+    /// Switches an already-open conversation's pager to `tab`. A fresh open seeds
+    /// the tab from `selectedInitialTab`, but reselecting the conversation already
+    /// showing in a side-by-side layout is a no-op (the id setter's equality guard
+    /// suppresses it and the mounted view has latched its initial tab), so that
+    /// case is routed through the notification the detail view listens for. Posted
+    /// unconditionally: when nothing is on screen for this id yet, no one is
+    /// listening and the fresh-open seed takes over.
+    private func requestTab(_ tab: ConversationTab, for conversationId: String) {
+        NotificationCenter.default.post(
+            name: .selectConversationTabRequested,
+            object: nil,
+            userInfo: ["conversationId": conversationId, "tab": tab.rawValue]
+        )
     }
 
     /// Returns the agent inbox id to open the DM page for, when the DM holds the

--- a/Convos/Conversations List/View Controller/ConversationsViewController.swift
+++ b/Convos/Conversations List/View Controller/ConversationsViewController.swift
@@ -831,29 +831,33 @@ extension ConversationsViewController: UICollectionViewDelegate {
             quickActions.append(muteAction)
         }
 
-        let quickMenu = UIMenu(title: "", options: .displayInline, children: quickActions)
-        actions.append(quickMenu)
-
-        // Open a specific tab (only for conversations that have an agent).
-        // Gated on the sticky `hasHadVerifiedAgent` flag rather than the volatile
-        // folded-in `agentDm` summary, which comes and goes as member sync
-        // rewrites the group's roster.
+        // Open a specific tab, rendered as the menu's top row: two icon-over-label
+        // tiles side by side. Only for conversations that have an agent. Gated on
+        // the sticky `hasHadVerifiedAgent` flag rather than the volatile folded-in
+        // `agentDm` summary, which comes and goes as member sync rewrites the
+        // group's roster.
         if !conversation.isPendingInvite && conversation.hasHadVerifiedAgent {
             let openAgentDmAction = UIAction(
-                title: "Open Agent DM",
-                image: UIImage(systemName: "person.bubble")
+                title: "Agent",
+                image: UIImage(systemName: "a.circle.fill")
             ) { [weak self] _ in
                 self?.onOpenAgentDm?(conversation)
             }
             let openThingsAction = UIAction(
-                title: "Open Things",
-                image: UIImage(systemName: "square.grid.2x2")
+                title: "Things",
+                image: UIImage(systemName: "square.grid.2x2.fill")
             ) { [weak self] _ in
                 self?.onOpenThings?(conversation)
             }
             let openMenu = UIMenu(title: "", options: .displayInline, children: [openAgentDmAction, openThingsAction])
+            // Lays the two out as a row of icon-over-label tiles rather than
+            // full-width rows.
+            openMenu.preferredElementSize = .medium
             actions.append(openMenu)
         }
+
+        let quickMenu = UIMenu(title: "", options: .displayInline, children: quickActions)
+        actions.append(quickMenu)
 
         // Explode (only for creators of non-pending conversations)
         if !conversation.isPendingInvite && conversation.creator.isCurrentUser {

--- a/Convos/Conversations List/View Controller/ConversationsViewController.swift
+++ b/Convos/Conversations List/View Controller/ConversationsViewController.swift
@@ -807,7 +807,7 @@ extension ConversationsViewController: UICollectionViewDelegate {
 
         // Pin/Unpin
         let pinTitle = conversation.isPinned ? "Unfav" : "Fav"
-        let pinImage = UIImage(systemName: conversation.isPinned ? "star.slash.fill" : "star.fill")
+        let pinImage = UIImage(systemName: conversation.isPinned ? "star.slash" : "star")
         let pinAction = UIAction(title: pinTitle, image: pinImage) { [weak self] _ in
             self?.onTogglePin?(conversation)
         }
@@ -824,7 +824,7 @@ extension ConversationsViewController: UICollectionViewDelegate {
 
             // Mute/Unmute
             let muteTitle = conversation.isMuted ? "Unmute" : "Mute"
-            let muteImage = UIImage(systemName: conversation.isMuted ? "bell.fill" : "bell.slash.fill")
+            let muteImage = UIImage(systemName: conversation.isMuted ? "bell" : "bell.slash")
             let muteAction = UIAction(title: muteTitle, image: muteImage) { [weak self] _ in
                 self?.onToggleMute?(conversation)
             }
@@ -839,13 +839,13 @@ extension ConversationsViewController: UICollectionViewDelegate {
         if !conversation.isPendingInvite && conversation.hasHadVerifiedAgent {
             let openAgentDmAction = UIAction(
                 title: "Agent",
-                image: UIImage(systemName: "a.circle.fill")
+                image: UIImage(systemName: "a.circle")
             ) { [weak self] _ in
                 self?.onOpenAgentDm?(conversation)
             }
             let openThingsAction = UIAction(
                 title: "Things",
-                image: UIImage(systemName: "square.grid.2x2.fill")
+                image: UIImage(systemName: "square.grid.2x2")
             ) { [weak self] _ in
                 self?.onOpenThings?(conversation)
             }

--- a/Convos/Conversations List/View Controller/ConversationsViewController.swift
+++ b/Convos/Conversations List/View Controller/ConversationsViewController.swift
@@ -103,6 +103,8 @@ final class ConversationsViewController: UIViewController {
     // MARK: - Callbacks
 
     var onSelectConversation: ((Conversation) -> Void)?
+    var onOpenAgentDm: ((Conversation) -> Void)?
+    var onOpenThings: ((Conversation) -> Void)?
     var onConfirmedDeleteConversation: ((Conversation) -> Void)?
     var onExplodeConversation: ((Conversation) -> Void)?
     var onToggleMute: ((Conversation) -> Void)?
@@ -831,6 +833,27 @@ extension ConversationsViewController: UICollectionViewDelegate {
 
         let quickMenu = UIMenu(title: "", options: .displayInline, children: quickActions)
         actions.append(quickMenu)
+
+        // Open a specific tab (only for conversations that have an agent).
+        // Gated on the sticky `hasHadVerifiedAgent` flag rather than the volatile
+        // folded-in `agentDm` summary, which comes and goes as member sync
+        // rewrites the group's roster.
+        if !conversation.isPendingInvite && conversation.hasHadVerifiedAgent {
+            let openAgentDmAction = UIAction(
+                title: "Open Agent DM",
+                image: UIImage(systemName: "person.bubble")
+            ) { [weak self] _ in
+                self?.onOpenAgentDm?(conversation)
+            }
+            let openThingsAction = UIAction(
+                title: "Open Things",
+                image: UIImage(systemName: "square.grid.2x2")
+            ) { [weak self] _ in
+                self?.onOpenThings?(conversation)
+            }
+            let openMenu = UIMenu(title: "", options: .displayInline, children: [openAgentDmAction, openThingsAction])
+            actions.append(openMenu)
+        }
 
         // Explode (only for creators of non-pending conversations)
         if !conversation.isPendingInvite && conversation.creator.isCurrentUser {

--- a/Convos/Conversations List/View Controller/ConversationsViewRepresentable.swift
+++ b/Convos/Conversations List/View Controller/ConversationsViewRepresentable.swift
@@ -19,6 +19,8 @@ struct ConversationsViewRepresentable: UIViewControllerRepresentable {
 
     // Callbacks
     var onSelectConversation: ((Conversation) -> Void)?
+    var onOpenAgentDm: ((Conversation) -> Void)?
+    var onOpenThings: ((Conversation) -> Void)?
     var onConfirmedDeleteConversation: ((Conversation) -> Void)?
     var onExplodeConversation: ((Conversation) -> Void)?
     var onToggleMute: ((Conversation) -> Void)?
@@ -59,6 +61,8 @@ struct ConversationsViewRepresentable: UIViewControllerRepresentable {
 
     private func configureCallbacks(_ viewController: ConversationsViewController) {
         viewController.onSelectConversation = onSelectConversation
+        viewController.onOpenAgentDm = onOpenAgentDm
+        viewController.onOpenThings = onOpenThings
         viewController.onConfirmedDeleteConversation = onConfirmedDeleteConversation
         viewController.onExplodeConversation = onExplodeConversation
         viewController.onToggleMute = onToggleMute

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -23,6 +23,13 @@ public extension Notification.Name {
     /// selecting the group again is a no-op, so the page can't be seeded the way
     /// a fresh open is.
     static let selectAgentDmPageRequested: Notification.Name = Notification.Name("SelectAgentDmPageRequested")
+    /// Requests that an already-open conversation switch its pager to a specific
+    /// tab. Posted (with `userInfo["conversationId"]` and `userInfo["tab"]` = the
+    /// `ConversationTab` raw value) by the list's "Open Agent DM" / "Open Things"
+    /// context-menu actions, which reselect a conversation that may already be on
+    /// screen in a side-by-side layout - selecting the same id again is a no-op,
+    /// so the page can't be seeded the way a fresh open is.
+    static let selectConversationTabRequested: Notification.Name = Notification.Name("SelectConversationTabRequested")
     /// One conversation arriving on, or leaving, the screen. Posted with
     /// `userInfo["conversationId"]` and `userInfo["isOnScreen"]`, by each lane for
     /// itself: a conversation shows its group and its agent DM together, so both

--- a/ConvosTests/ConversationsViewModelTabSelectionTests.swift
+++ b/ConvosTests/ConversationsViewModelTabSelectionTests.swift
@@ -1,0 +1,126 @@
+@testable import Convos
+import ConvosConnections
+import ConvosCore
+import XCTest
+
+@MainActor
+final class ConversationsViewModelTabSelectionTests: XCTestCase {
+    func testSelectAgentDmSetsAgentTabOverride() {
+        let conversation = Conversation.mock(id: "conv-agent", name: "Agent convo")
+        let viewModel = makeViewModel(with: [conversation])
+
+        viewModel.selectAgentDm(conversation)
+
+        XCTAssertEqual(viewModel.selectedInitialTab, .agent)
+        XCTAssertNil(viewModel.selectedInitialAgentDmInboxId,
+                     "Open Agent DM drives the tab via the override, not the folded-in DM inbox id")
+        XCTAssertEqual(viewModel.selectedConversationId, conversation.id)
+    }
+
+    func testSelectThingsSetsContextTabOverride() {
+        let conversation = Conversation.mock(id: "conv-things", name: "Things convo")
+        let viewModel = makeViewModel(with: [conversation])
+
+        viewModel.selectThings(conversation)
+
+        XCTAssertEqual(viewModel.selectedInitialTab, .context)
+        XCTAssertNil(viewModel.selectedInitialAgentDmInboxId)
+        XCTAssertEqual(viewModel.selectedConversationId, conversation.id)
+    }
+
+    func testNormalSelectClearsPriorTabOverride() {
+        let agentConversation = Conversation.mock(id: "conv-a", name: "A")
+        let groupConversation = Conversation.mock(id: "conv-b", name: "B")
+        let viewModel = makeViewModel(with: [agentConversation, groupConversation])
+
+        viewModel.selectThings(agentConversation)
+        XCTAssertEqual(viewModel.selectedInitialTab, .context)
+
+        viewModel.select(groupConversation)
+
+        XCTAssertNil(viewModel.selectedInitialTab,
+                     "A normal tap must not inherit a prior Open Things/Agent override")
+        XCTAssertEqual(viewModel.selectedConversationId, groupConversation.id)
+    }
+
+    func testDismissingSessionClearsTabOverride() {
+        let conversation = Conversation.mock(id: "conv-dismiss", name: "Dismiss")
+        let viewModel = makeViewModel(with: [conversation])
+
+        viewModel.selectThings(conversation)
+        XCTAssertEqual(viewModel.selectedInitialTab, .context)
+        XCTAssertNotNil(viewModel.selectedConversationViewModel)
+
+        viewModel.selectedConversationId = nil
+
+        XCTAssertNil(viewModel.selectedInitialTab,
+                     "Ending an open session resets the per-open tab override")
+        XCTAssertNil(viewModel.selectedInitialAgentDmInboxId)
+    }
+
+    func testNormalSelectMarksGroupRead() async throws {
+        let localStateWriter = MockConversationLocalStateWriter()
+        let conversation = Conversation.mock(id: "conv-read", name: "Read me")
+        let viewModel = makeViewModel(with: [conversation], localStateWriter: localStateWriter)
+
+        viewModel.select(conversation)
+
+        try await waitUntilMainActor(timeout: 1.0) {
+            localStateWriter.unreadStates[conversation.id] == false
+        }
+        XCTAssertEqual(localStateWriter.unreadStates[conversation.id], false,
+                       "Opening on the Group tab clears the group's unread")
+    }
+
+    func testOpenThingsDoesNotMarkGroupRead() async throws {
+        let localStateWriter = MockConversationLocalStateWriter()
+        let conversation = Conversation.mock(id: "conv-things-unread", name: "Keep unread")
+        let viewModel = makeViewModel(with: [conversation], localStateWriter: localStateWriter)
+
+        viewModel.selectThings(conversation)
+
+        try await Task.sleep(nanoseconds: 300_000_000)
+        XCTAssertNil(localStateWriter.unreadStates[conversation.id],
+                     "Opening the Things tab must leave the Group lane's unread untouched")
+    }
+
+    func testOpenAgentDmDoesNotMarkGroupRead() async throws {
+        let localStateWriter = MockConversationLocalStateWriter()
+        let conversation = Conversation.mock(id: "conv-agent-unread", name: "Keep unread")
+        let viewModel = makeViewModel(with: [conversation], localStateWriter: localStateWriter)
+
+        viewModel.selectAgentDm(conversation)
+
+        try await Task.sleep(nanoseconds: 300_000_000)
+        XCTAssertNil(localStateWriter.unreadStates[conversation.id],
+                     "Opening the Agent DM tab must leave the Group lane's unread untouched")
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel(
+        with conversations: [Conversation],
+        localStateWriter: MockConversationLocalStateWriter = MockConversationLocalStateWriter()
+    ) -> ConversationsViewModel {
+        let messagingService = MockMessagingService(conversationLocalStateWriter: localStateWriter)
+        let session = MockInboxesService(mockMessagingService: messagingService)
+        let viewModel = ConversationsViewModel(session: session)
+        viewModel.conversations = conversations
+        return viewModel
+    }
+
+    private func waitUntilMainActor(
+        timeout: TimeInterval,
+        interval: TimeInterval = 0.02,
+        condition: @MainActor () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() {
+                return
+            }
+            try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+        }
+        XCTFail("waitUntilMainActor timed out after \(timeout)s")
+    }
+}


### PR DESCRIPTION
Long-pressing a conversation row that has an agent now offers **Open Agent DM** and **Open Things** in the context menu (both the UIKit list rows and the SwiftUI pinned tiles), each opening the conversation directly on the chosen tab via a new `initialTabOverride` on `ConversationView` that supersedes the unread heuristic. The items are gated on the sticky `hasHadVerifiedAgent` flag rather than the volatile folded-in `agentDm` summary, which churned with member sync and was making the items disappear after first use. The pager is realigned after seeding a non-adjacent tab, because its container measures zero on the first layout pass and the Space page lays out a beat later, which otherwise left "Open Things" settled on the Agent page in between. All three paths were verified on-device: a normal tap opens Group, Open Agent DM opens the Agent tab, and Open Things opens the Space page.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790288438&installation_model_id=20076&pr_number=1434&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1434&signature=a5309fdd2c159d0b4d11d0acbcb434cce4211b4c448a094a04e3fd63e303b2bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add "Open Agent DM" and "Open Things" context-menu items to conversation list
> - Adds a `ControlGroup`/`UIMenu` with "Agent" and "Things" quick-open actions to the conversation context menu for conversations that have had a verified agent
> - Introduces `initialTabOverride: ConversationTab?` on `ConversationView` so a pushed detail can open on a specific tab, and adds a `.selectConversationTabRequested` notification so an already-mounted detail switches tabs without reselection
> - `ConversationsViewModel.selectAgentDm` and `selectThings` set the override, post the tab request, and skip marking the Group lane read; normal selection still marks Group read
> - Adds a `realignPagerAfterSeeding` helper that re-drives the pager offset after layout so the visible page matches the selected segmented control state
> - Behavioral Change: opening via Agent or Things no longer marks the Group lane as read on open or session end — check `ConversationsViewModel.updateSelectionState` where `opensGroupTab` is now derived from whether `selectedInitialTab` is nil
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 664afca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->