### PR TITLE
DO NOT USE - Show an agent's SMS number on its contact card

### DIFF
--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -2365,7 +2365,6 @@ private struct ContactDetailContactInfoSection: View {
     }
 }
 
-
 // MARK: - Debug instance id row (internal builds only)
 
 /// Internal-build-only row surfacing the agent runtime's `instanceId`

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -537,6 +537,7 @@ struct ContactDetailView: View {
                     showBlock: !mode.isCurrentUser && !contact.isUnsavedAgentPlaceholder,
                     contactDisplayName: contact.resolvedDisplayName,
                     agentEmail: contact.agentEmail,
+                    agentPhone: contact.agentPhone,
                     agentInstanceId: contact.agentInstanceId,
                     showsInstanceIdRow: showsInstanceIdRow,
                     agentAttestation: contact.agentAttestation,
@@ -2005,6 +2006,11 @@ private struct ContactDetailActions: View {
     /// "Contact Info" section under Share when present; nil (humans and
     /// older agents created before addresses were assigned) hides it.
     let agentEmail: String?
+    /// Agent's SMS number from its profile metadata, stamped by the
+    /// assistants worker when it provisions one. Renders the Text row of
+    /// the "Contact Info" section; nil for humans and for agents without
+    /// SMS provisioned. The section appears when either channel exists.
+    let agentPhone: String?
     /// Always plumbed through when the contact has one. Display gate
     /// is `showsInstanceIdRow`, not nullability of this field.
     let agentInstanceId: String?
@@ -2041,9 +2047,10 @@ private struct ContactDetailActions: View {
             if showShare {
                 shareRow
             }
-            if let agentEmail {
-                ContactDetailEmailSection(
+            if agentEmail != nil || agentPhone != nil {
+                ContactDetailContactInfoSection(
                     email: agentEmail,
+                    phone: agentPhone,
                     contactDisplayName: contactDisplayName
                 )
             }
@@ -2179,26 +2186,67 @@ private struct ContactDetailActionRow: View {
 /// only when the agent's profile metadata carries an email - older agents
 /// created before the runtime assigned addresses don't have one. Header +
 /// rounded-card shape mirrors `AgentTemplateConversationsSection`.
-private struct ContactDetailEmailSection: View {
-    let email: String
+/// Which reachable address a Contact Info row is showing. Mirrors the
+/// pattern `ContactCardMode` uses: one view parameterized by the surface it
+/// is drawing, rather than a near-copy per channel.
+private enum ContactChannel {
+    case email
+    case text
+
+    /// The caption under the value.
+    var caption: String {
+        switch self {
+        case .email: return "Email"
+        case .text: return "Text"
+        }
+    }
+
+    /// The scheme that reaches this channel from the value.
+    var urlScheme: String {
+        switch self {
+        case .email: return "mailto:"
+        case .text: return "sms:"
+        }
+    }
+
+    /// Identifier stem for the row's controls, so UI tests address a row by
+    /// channel rather than by position in the section.
+    var identifierStem: String {
+        switch self {
+        case .email: return "contact-detail-email"
+        case .text: return "contact-detail-phone"
+        }
+    }
+
+    var copyAccessibilityLabel: String {
+        switch self {
+        case .email: return "Copy email address"
+        case .text: return "Copy phone number"
+        }
+    }
+
+    func openAccessibilityLabel(displayName: String, value: String) -> String {
+        switch self {
+        case .email: return "Email \(displayName) at \(value)"
+        case .text: return "Text \(displayName) at \(value)"
+        }
+    }
+}
+
+/// One reachable address on the contact card: the value, the kind of address
+/// it is, and a copy control. Tapping the value hands it to the app that owns
+/// the channel -- Mail for an address, Messages for a number.
+private struct ContactDetailChannelCard: View {
+    let channel: ContactChannel
+    let value: String
     let contactDisplayName: String
 
     @Environment(\.openURL) private var openURL: OpenURLAction
     @State private var didCopy: Bool = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
-            Text("Contact Info")
-                .font(.footnote)
-                .foregroundStyle(.colorTextSecondary)
-                .padding(.leading, DesignConstants.Spacing.step2x)
-            emailCard
-        }
-    }
-
-    private var emailCard: some View {
         HStack(spacing: DesignConstants.Spacing.step2x) {
-            emailButton
+            valueButton
             copyButton
         }
         .padding(.vertical, DesignConstants.Spacing.step4x)
@@ -2209,16 +2257,20 @@ private struct ContactDetailEmailSection: View {
         )
     }
 
-    private var emailButton: some View {
-        let action = { openMailComposer() }
+    private var valueButton: some View {
+        let openLabel: String = channel.openAccessibilityLabel(
+            displayName: contactDisplayName,
+            value: value
+        )
+        let action = { open() }
         return Button(action: action) {
             VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
-                Text(email)
+                Text(value)
                     .font(.callout.weight(.medium))
                     .foregroundStyle(.colorTextPrimary)
                     .lineLimit(1)
                     .truncationMode(.middle)
-                Text("Email")
+                Text(channel.caption)
                     .font(.footnote)
                     .foregroundStyle(.colorTextSecondary)
             }
@@ -2226,14 +2278,15 @@ private struct ContactDetailEmailSection: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Email \(contactDisplayName) at \(email)")
-        .accessibilityIdentifier("contact-detail-email")
+        .accessibilityLabel(openLabel)
+        .accessibilityIdentifier(channel.identifierStem)
     }
 
     private var copyButton: some View {
         let iconName: String = didCopy ? "checkmark" : "square.on.square"
         let iconColor: Color = didCopy ? .colorTextPrimary : .colorTextSecondary
-        let label: String = didCopy ? "Copied" : "Copy email address"
+        let label: String = didCopy ? "Copied" : channel.copyAccessibilityLabel
+        let identifier: String = "\(channel.identifierStem)-copy"
         let action = { copyToClipboard() }
         return Button(action: action) {
             Image(systemName: iconName)
@@ -2244,23 +2297,74 @@ private struct ContactDetailEmailSection: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel(label)
-        .accessibilityIdentifier("contact-detail-email-copy")
+        .accessibilityIdentifier(identifier)
     }
 
-    private func openMailComposer() {
-        guard let url = URL(string: "mailto:\(email)") else { return }
+    /// `sms:` rejects the spaces and punctuation a number is displayed with,
+    /// so the scheme gets the dialable form while the row keeps showing the
+    /// readable one. A value the initializer still rejects opens nothing,
+    /// which is what a non-tappable row did before.
+    private var schemeValue: String {
+        switch channel {
+        case .email:
+            return value
+        case .text:
+            return value.filter { $0.isNumber || $0 == "+" }
+        }
+    }
+
+    private func open() {
+        guard let url = URL(string: "\(channel.urlScheme)\(schemeValue)") else { return }
         openURL(url)
     }
 
     private func copyToClipboard() {
-        UIPasteboard.general.string = email
+        UIPasteboard.general.string = value
         didCopy = true
         Task {
-            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            try? await Task.sleep(nanoseconds: Constant.copyFeedbackNanoseconds)
             didCopy = false
         }
     }
+
+    private enum Constant {
+        static let copyFeedbackNanoseconds: UInt64 = 1_500_000_000
+    }
 }
+
+/// The contact card's Contact Info section: every way to reach this agent
+/// from outside Convos. A channel the runtime has not provisioned is absent
+/// rather than drawn empty; the call site omits the section when neither
+/// exists, so the header never stands alone.
+private struct ContactDetailContactInfoSection: View {
+    let email: String?
+    let phone: String?
+    let contactDisplayName: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
+            Text("Contact Info")
+                .font(.footnote)
+                .foregroundStyle(.colorTextSecondary)
+                .padding(.leading, DesignConstants.Spacing.step2x)
+            if let email {
+                ContactDetailChannelCard(
+                    channel: .email,
+                    value: email,
+                    contactDisplayName: contactDisplayName
+                )
+            }
+            if let phone {
+                ContactDetailChannelCard(
+                    channel: .text,
+                    value: phone,
+                    contactDisplayName: contactDisplayName
+                )
+            }
+        }
+    }
+}
+
 
 // MARK: - Debug instance id row (internal builds only)
 
@@ -2506,6 +2610,7 @@ extension Contact {
         let emoji: String? = member.profile.profileEmoji
         let instanceId: String? = member.profile.agentInstanceId
         let email: String? = member.profile.agentEmail
+        let phone: String? = member.profile.agentPhone
         let attestation: String? = member.profile.agentAttestation
         // `ConversationMember.agentVerification` is `.unverified` for ordinary
         // humans too. Carrying that value onto a Contact makes `Contact.isAgent`
@@ -2523,6 +2628,7 @@ extension Contact {
                 .with(agentInstanceId: instanceId)
                 .with(agentVerification: agentVerification)
                 .with(agentEmail: email)
+                .with(agentPhone: phone)
                 .with(agentAttestation: attestation)
         }
         return .synthetic(
@@ -2540,6 +2646,7 @@ extension Contact {
             agentInstanceId: instanceId,
             agentEmail: email
         )
+        .with(agentPhone: phone)
         .with(agentAttestation: attestation)
     }
 }
@@ -2555,7 +2662,11 @@ struct SocialAgentProfilePrototypeView: View {
             conversationId: "fixture-nashville-boys",
             name: "Maple",
             avatar: nil,
-            isAgent: true
+            isAgent: true,
+            metadata: [
+                "email": .string("maple.9f3ab2@ai.convos.org"),
+                "phone": .string("+1 (615) 555-0142"),
+            ]
         ),
         role: .member,
         isCurrentUser: false,
@@ -2652,14 +2763,15 @@ struct SocialAgentProfilePrototypeView: View {
     }
 }
 
-#Preview("Agent template with email") {
+#Preview("Agent template with email and number") {
     NavigationStack {
         ContactDetailView(
             contact: .mock(
                 displayName: "Tifoso",
                 agentVerification: .verified(.convos),
                 agentTemplatePublishedURL: "https://agents-dev.convos.org/tifoso.pnw1o",
-                agentEmail: "tifoso.123456@ai.convos.org"
+                agentEmail: "tifoso.123456@ai.convos.org",
+                agentPhone: "+1 (615) 555-0142"
             ),
             contactsWriter: MockContactsWriter(),
             contactsRepository: MockContactsRepository(),

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
@@ -58,6 +58,13 @@ public struct Contact: Hashable, Identifiable, Sendable {
     /// runtime assigned addresses. Drives the contact card's Contact Info
     /// section.
     public let agentEmail: String?
+    /// The agent's SMS number in E.164, read from the per-conversation
+    /// member profile metadata at resolution time. Not persisted on
+    /// `DBContact`; overlaid via `with(agentPhone:)` in
+    /// `Contact.resolved(member:...)`. nil for human contacts and for
+    /// agents whose runtime has not provisioned SMS. Drives the Text
+    /// row in the contact card's Contact Info section.
+    public let agentPhone: String?
     /// The agent's published attestation signature, read from the
     /// per-conversation member profile metadata at resolution time. Not
     /// persisted on `DBContact`. Surfaced on the contact card behind a
@@ -87,6 +94,7 @@ public struct Contact: Hashable, Identifiable, Sendable {
         profileEmoji: String? = nil,
         agentInstanceId: String? = nil,
         agentEmail: String? = nil,
+        agentPhone: String? = nil,
         agentAttestation: String? = nil,
         agentDescription: String? = nil
     ) {
@@ -105,6 +113,7 @@ public struct Contact: Hashable, Identifiable, Sendable {
         self.profileEmoji = profileEmoji
         self.agentInstanceId = agentInstanceId
         self.agentEmail = agentEmail
+        self.agentPhone = agentPhone
         self.agentAttestation = agentAttestation
         self.agentDescription = agentDescription
     }
@@ -201,7 +210,8 @@ extension Contact {
         agentTemplatePublishedURL: String? = nil,
         profileEmoji: String? = nil,
         agentInstanceId: String? = nil,
-        agentEmail: String? = nil
+        agentEmail: String? = nil,
+        agentPhone: String? = nil
     ) -> Contact {
         Contact(
             inboxId: inboxId,
@@ -218,7 +228,8 @@ extension Contact {
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
             agentInstanceId: agentInstanceId,
-            agentEmail: agentEmail
+            agentEmail: agentEmail,
+            agentPhone: agentPhone
         )
     }
 
@@ -242,7 +253,8 @@ extension Contact {
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
             agentInstanceId: agentInstanceId,
-            agentEmail: agentEmail
+            agentEmail: agentEmail,
+            agentPhone: agentPhone
         )
     }
 
@@ -266,7 +278,8 @@ extension Contact {
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
             agentInstanceId: agentInstanceId,
-            agentEmail: agentEmail
+            agentEmail: agentEmail,
+            agentPhone: agentPhone
         )
     }
 
@@ -294,7 +307,8 @@ extension Contact {
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
             agentInstanceId: agentInstanceId,
-            agentEmail: agentEmail
+            agentEmail: agentEmail,
+            agentPhone: agentPhone
         )
     }
 
@@ -318,7 +332,8 @@ extension Contact {
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
             agentInstanceId: agentInstanceId,
-            agentEmail: agentEmail
+            agentEmail: agentEmail,
+            agentPhone: agentPhone
         )
     }
 
@@ -340,6 +355,7 @@ extension Contact {
             profileEmoji: profileEmoji,
             agentInstanceId: agentInstanceId,
             agentEmail: agentEmail,
+            agentPhone: agentPhone,
             agentAttestation: agentAttestation
         )
     }
@@ -365,6 +381,32 @@ extension Contact {
             profileEmoji: profileEmoji,
             agentInstanceId: agentInstanceId,
             agentEmail: agentEmail,
+            agentPhone: agentPhone,
+            agentAttestation: agentAttestation
+        )
+    }
+
+    /// Returns a copy with `agentPhone` overlaid. Mirrors `with(agentEmail:)`:
+    /// the number comes from a live per-conversation member profile and is not
+    /// persisted on `DBContact`.
+    public func with(agentPhone: String?) -> Contact {
+        Contact(
+            inboxId: inboxId,
+            displayName: displayName,
+            avatarURL: avatarURL,
+            avatarSalt: avatarSalt,
+            avatarNonce: avatarNonce,
+            avatarKey: avatarKey,
+            addedAt: addedAt,
+            addedViaConversationId: addedViaConversationId,
+            isBlocked: isBlocked,
+            agentVerification: agentVerification,
+            agentTemplateId: agentTemplateId,
+            agentTemplatePublishedURL: agentTemplatePublishedURL,
+            profileEmoji: profileEmoji,
+            agentInstanceId: agentInstanceId,
+            agentEmail: agentEmail,
+            agentPhone: agentPhone,
             agentAttestation: agentAttestation
         )
     }
@@ -390,6 +432,7 @@ extension Contact {
             profileEmoji: profileEmoji,
             agentInstanceId: agentInstanceId,
             agentEmail: agentEmail,
+            agentPhone: agentPhone,
             agentAttestation: agentAttestation
         )
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
@@ -210,6 +210,7 @@ public struct Profile: Codable, Identifiable, Hashable, Sendable {
         static let publishedURLKey: String = "publishedUrl"
         static let instanceIdKey: String = "instanceId"
         static let emailKey: String = "email"
+        static let phoneKey: String = "phone"
         static let variantKey: String = "variant"
     }
 }
@@ -324,6 +325,19 @@ extension Profile {
     /// `agentTemplateId` above.
     public var agentEmail: String? {
         metadata?[Constant.emailKey]?.stringValue.flatMap { value in
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
+    /// The agent's SMS number in E.164, read from the agent's per-conversation
+    /// profile metadata. The assistants worker stamps `phone` onto the profile
+    /// when it provisions a number, so an agent that has never provisioned SMS
+    /// reads as nil, as do human members. Drives the Text row in the contact
+    /// card's Contact Info section. Empty / whitespace-only values are coerced
+    /// to nil, mirroring `agentEmail` above.
+    public var agentPhone: String? {
+        metadata?[Constant.phoneKey]?.stringValue.flatMap { value in
             let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmed.isEmpty ? nil : trimmed
         }


### PR DESCRIPTION
Targets `codex/shane-mac-do-not-merge-message-bubble-ux` rather than `dev`, so it lands in the ad-hoc build (#1341) Shane is demoing from. Based directly on that branch's head, so it merges without conflict.

## What

The agent's SMS number now appears on its contact card, beside the email address that was already there. Tapping it opens Messages addressed to the agent; the copy control mirrors the email row.

## Why this is small

The number already existed and was simply invisible. The assistants worker has been stamping `phone` onto the agent's XMTP profile since it started provisioning numbers — exactly the way it stamps `email`, which iOS already read as `Profile.agentEmail`. Nothing on this side ever read the other key.

So there is **no backend change here**. The number reaches the phone today; this only surfaces it.

## Changes

- `Profile.agentPhone` — reads `metadata["phone"]`, coercing empty/whitespace values to nil. A direct mirror of `agentEmail` directly above it.
- `Contact.agentPhone` + `with(agentPhone:)` — the same overlay plumbing `agentEmail` uses, applied before `with(agentAttestation:)` so that overlay stays last as its doc comment requires.
- Contact Info section — the email row was a single-channel view, so rather than clone it, it becomes one card parameterized by the channel it draws (the pattern `ContactCardMode` already uses). `sms:` gets the number stripped to digits and `+`, while the row keeps showing the readable form.

Rows are independent: an agent with only one provisioned channel shows only that row, and the section is omitted when there is neither, so the header never stands alone. `agentPhone` defaults to `nil` throughout, so no existing caller changes.

The DEBUG launch fixture and the preview carry both channels, so the section can be reviewed in the simulator without a provisioned agent behind it.

## Testing

**Not built.** This was written in a Linux container with no Xcode, so it has had no compile, no SwiftLint, and no SwiftFormat. It was reviewed against the conventions in `CLAUDE.md`, and every construction site of the changed types was checked, but that is review rather than verification — please build before relying on it.

Worth exercising once built:

- An agent with both channels — both rows, correct captions.
- An agent with SMS but no email, and the reverse — only the provisioned row appears.
- A human contact — no Contact Info section at all.
- Tapping the number opens Messages pre-addressed; tapping the address opens Mail.

## Related

Inbound texts are currently truncated to 80 characters before reaching the agent. That fix is server-side, on `claude/twilio-sms-convos-ha79jz` in `convos-assistants`, and is unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUV7w9MkMLRUfL4vek714Y)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790290717&installation_model_id=20076&pr_number=1435&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1435&signature=12a53c0988d5ff153ee2ede9f71fcebc959c294ea4fa99ff5c1bb319b752e92e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent SMS number to contact detail card
> - Adds optional `agentPhone` to `Contact`, sourced from `Profile` metadata under a new `phoneKey` ("phone"), mirroring the existing `agentEmail` pattern
> - Introduces `ContactChannel` enum and `ContactDetailChannelCard` to render a channel-agnostic row that supports both email (`mailto:`) and SMS (`sms:`) with copy-to-clipboard
> - Replaces the email-only `ContactDetailEmailSection` with `ContactDetailContactInfoSection`, which renders one card per available channel (Email and/or Text)\n- SMS payload is normalized to digits and `+` before opening the Messages app, regardless of display formatting
> - Risk: `Contact.with(...)` copy methods now carry through `agentPhone`; callers building partial copies via older `with` variants will preserve the phone value, which is the intended behavior but changes prior copy semantics
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 325097a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->