### PR TITLE
Show an agent's SMS number on its contact card

### DIFF
--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -1337,7 +1337,6 @@ private struct ContactDetailContactInfoSection: View {
     }
 }
 
-
 // MARK: - Debug instance id row (internal builds only)
 
 /// Internal-build-only row surfacing the agent runtime's `instanceId`

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -379,6 +379,7 @@ struct ContactDetailView: View {
                     showBlock: !mode.isCurrentUser && !contact.isAgentSharePlaceholder,
                     contactDisplayName: contact.resolvedDisplayName,
                     agentEmail: contact.agentEmail,
+                    agentPhone: contact.agentPhone,
                     agentInstanceId: contact.agentInstanceId,
                     showsInstanceIdRow: showsInstanceIdRow,
                     agentAttestation: contact.agentAttestation,
@@ -861,6 +862,11 @@ private struct ContactDetailActions: View {
     /// "Contact Info" section under Share when present; nil (humans and
     /// older agents created before addresses were assigned) hides it.
     let agentEmail: String?
+    /// Agent's SMS number from its profile metadata, stamped by the
+    /// assistants worker when it provisions one. Renders the Text row of
+    /// the "Contact Info" section; nil for humans and for agents without
+    /// SMS provisioned. The section appears when either channel exists.
+    let agentPhone: String?
     /// Always plumbed through when the contact has one. Display gate
     /// is `showsInstanceIdRow`, not nullability of this field.
     let agentInstanceId: String?
@@ -900,9 +906,10 @@ private struct ContactDetailActions: View {
             if showShare {
                 shareRow
             }
-            if let agentEmail {
-                ContactDetailEmailSection(
+            if agentEmail != nil || agentPhone != nil {
+                ContactDetailContactInfoSection(
                     email: agentEmail,
+                    phone: agentPhone,
                     contactDisplayName: contactDisplayName
                 )
             }
@@ -1151,26 +1158,67 @@ private struct ContactDetailModelRow: View {
 /// only when the agent's profile metadata carries an email - older agents
 /// created before the runtime assigned addresses don't have one. Header +
 /// rounded-card shape mirrors `AgentTemplateConversationsSection`.
-private struct ContactDetailEmailSection: View {
-    let email: String
+/// Which reachable address a Contact Info row is showing. Mirrors the
+/// pattern `ContactCardMode` uses: one view parameterized by the surface it
+/// is drawing, rather than a near-copy per channel.
+private enum ContactChannel {
+    case email
+    case text
+
+    /// The caption under the value.
+    var caption: String {
+        switch self {
+        case .email: return "Email"
+        case .text: return "Text"
+        }
+    }
+
+    /// The scheme that reaches this channel from the value.
+    var urlScheme: String {
+        switch self {
+        case .email: return "mailto:"
+        case .text: return "sms:"
+        }
+    }
+
+    /// Identifier stem for the row's controls, so UI tests address a row by
+    /// channel rather than by position in the section.
+    var identifierStem: String {
+        switch self {
+        case .email: return "contact-detail-email"
+        case .text: return "contact-detail-phone"
+        }
+    }
+
+    var copyAccessibilityLabel: String {
+        switch self {
+        case .email: return "Copy email address"
+        case .text: return "Copy phone number"
+        }
+    }
+
+    func openAccessibilityLabel(displayName: String, value: String) -> String {
+        switch self {
+        case .email: return "Email \(displayName) at \(value)"
+        case .text: return "Text \(displayName) at \(value)"
+        }
+    }
+}
+
+/// One reachable address on the contact card: the value, the kind of address
+/// it is, and a copy control. Tapping the value hands it to the app that owns
+/// the channel -- Mail for an address, Messages for a number.
+private struct ContactDetailChannelCard: View {
+    let channel: ContactChannel
+    let value: String
     let contactDisplayName: String
 
     @Environment(\.openURL) private var openURL: OpenURLAction
     @State private var didCopy: Bool = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
-            Text("Contact Info")
-                .font(.footnote)
-                .foregroundStyle(.colorTextSecondary)
-                .padding(.leading, DesignConstants.Spacing.step2x)
-            emailCard
-        }
-    }
-
-    private var emailCard: some View {
         HStack(spacing: DesignConstants.Spacing.step2x) {
-            emailButton
+            valueButton
             copyButton
         }
         .padding(.vertical, DesignConstants.Spacing.step4x)
@@ -1181,16 +1229,20 @@ private struct ContactDetailEmailSection: View {
         )
     }
 
-    private var emailButton: some View {
-        let action = { openMailComposer() }
+    private var valueButton: some View {
+        let openLabel: String = channel.openAccessibilityLabel(
+            displayName: contactDisplayName,
+            value: value
+        )
+        let action = { open() }
         return Button(action: action) {
             VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
-                Text(email)
+                Text(value)
                     .font(.callout.weight(.medium))
                     .foregroundStyle(.colorTextPrimary)
                     .lineLimit(1)
                     .truncationMode(.middle)
-                Text("Email")
+                Text(channel.caption)
                     .font(.footnote)
                     .foregroundStyle(.colorTextSecondary)
             }
@@ -1198,14 +1250,15 @@ private struct ContactDetailEmailSection: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Email \(contactDisplayName) at \(email)")
-        .accessibilityIdentifier("contact-detail-email")
+        .accessibilityLabel(openLabel)
+        .accessibilityIdentifier(channel.identifierStem)
     }
 
     private var copyButton: some View {
         let iconName: String = didCopy ? "checkmark" : "square.on.square"
         let iconColor: Color = didCopy ? .colorTextPrimary : .colorTextSecondary
-        let label: String = didCopy ? "Copied" : "Copy email address"
+        let label: String = didCopy ? "Copied" : channel.copyAccessibilityLabel
+        let identifier: String = "\(channel.identifierStem)-copy"
         let action = { copyToClipboard() }
         return Button(action: action) {
             Image(systemName: iconName)
@@ -1216,23 +1269,74 @@ private struct ContactDetailEmailSection: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel(label)
-        .accessibilityIdentifier("contact-detail-email-copy")
+        .accessibilityIdentifier(identifier)
     }
 
-    private func openMailComposer() {
-        guard let url = URL(string: "mailto:\(email)") else { return }
+    /// `sms:` rejects the spaces and punctuation a number is displayed with,
+    /// so the scheme gets the dialable form while the row keeps showing the
+    /// readable one. A value the initializer still rejects opens nothing,
+    /// which is what a non-tappable row did before.
+    private var schemeValue: String {
+        switch channel {
+        case .email:
+            return value
+        case .text:
+            return value.filter { $0.isNumber || $0 == "+" }
+        }
+    }
+
+    private func open() {
+        guard let url = URL(string: "\(channel.urlScheme)\(schemeValue)") else { return }
         openURL(url)
     }
 
     private func copyToClipboard() {
-        UIPasteboard.general.string = email
+        UIPasteboard.general.string = value
         didCopy = true
         Task {
-            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            try? await Task.sleep(nanoseconds: Constant.copyFeedbackNanoseconds)
             didCopy = false
         }
     }
+
+    private enum Constant {
+        static let copyFeedbackNanoseconds: UInt64 = 1_500_000_000
+    }
 }
+
+/// The contact card's Contact Info section: every way to reach this agent
+/// from outside Convos. A channel the runtime has not provisioned is absent
+/// rather than drawn empty; the call site omits the section when neither
+/// exists, so the header never stands alone.
+private struct ContactDetailContactInfoSection: View {
+    let email: String?
+    let phone: String?
+    let contactDisplayName: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
+            Text("Contact Info")
+                .font(.footnote)
+                .foregroundStyle(.colorTextSecondary)
+                .padding(.leading, DesignConstants.Spacing.step2x)
+            if let email {
+                ContactDetailChannelCard(
+                    channel: .email,
+                    value: email,
+                    contactDisplayName: contactDisplayName
+                )
+            }
+            if let phone {
+                ContactDetailChannelCard(
+                    channel: .text,
+                    value: phone,
+                    contactDisplayName: contactDisplayName
+                )
+            }
+        }
+    }
+}
+
 
 // MARK: - Debug instance id row (internal builds only)
 
@@ -1478,6 +1582,7 @@ extension Contact {
         let emoji: String? = member.profile.profileEmoji
         let instanceId: String? = member.profile.agentInstanceId
         let email: String? = member.profile.agentEmail
+        let phone: String? = member.profile.agentPhone
         let attestation: String? = member.profile.agentAttestation
         if let stored = try? contactsRepository.fetchContact(inboxId: member.profile.inboxId) {
             let resolvedPublishedURL: String? = templatePublishedURL ?? stored.agentTemplatePublishedURL
@@ -1488,6 +1593,7 @@ extension Contact {
                 .with(agentInstanceId: instanceId)
                 .with(agentVerification: member.agentVerification)
                 .with(agentEmail: email)
+                .with(agentPhone: phone)
                 .with(agentAttestation: attestation)
         }
         return .synthetic(
@@ -1505,6 +1611,7 @@ extension Contact {
             agentInstanceId: instanceId,
             agentEmail: email
         )
+        .with(agentPhone: phone)
         .with(agentAttestation: attestation)
     }
 }
@@ -1560,14 +1667,15 @@ extension Contact {
     }
 }
 
-#Preview("Agent template with email") {
+#Preview("Agent template with email and number") {
     NavigationStack {
         ContactDetailView(
             contact: .mock(
                 displayName: "Tifoso",
                 agentVerification: .verified(.convos),
                 agentTemplatePublishedURL: "https://agents-dev.convos.org/tifoso.pnw1o",
-                agentEmail: "tifoso.123456@ai.convos.org"
+                agentEmail: "tifoso.123456@ai.convos.org",
+                agentPhone: "+1 (615) 555-0142"
             ),
             contactsWriter: MockContactsWriter(),
             contactsRepository: MockContactsRepository(),

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
@@ -58,6 +58,13 @@ public struct Contact: Hashable, Identifiable, Sendable {
     /// runtime assigned addresses. Drives the contact card's Contact Info
     /// section.
     public let agentEmail: String?
+    /// The agent's SMS number in E.164, read from the per-conversation
+    /// member profile metadata at resolution time. Not persisted on
+    /// `DBContact`; overlaid via `with(agentPhone:)` in
+    /// `Contact.resolved(member:...)`. nil for human contacts and for
+    /// agents whose runtime has not provisioned SMS. Drives the Text
+    /// row in the contact card's Contact Info section.
+    public let agentPhone: String?
     /// The agent's published attestation signature, read from the
     /// per-conversation member profile metadata at resolution time. Not
     /// persisted on `DBContact`. Surfaced on the contact card behind a
@@ -88,6 +95,7 @@ public struct Contact: Hashable, Identifiable, Sendable {
         profileEmoji: String? = nil,
         agentInstanceId: String? = nil,
         agentEmail: String? = nil,
+        agentPhone: String? = nil,
         agentAttestation: String? = nil,
         agentDescription: String? = nil
     ) {
@@ -106,6 +114,7 @@ public struct Contact: Hashable, Identifiable, Sendable {
         self.profileEmoji = profileEmoji
         self.agentInstanceId = agentInstanceId
         self.agentEmail = agentEmail
+        self.agentPhone = agentPhone
         self.agentAttestation = agentAttestation
         self.agentDescription = agentDescription
     }
@@ -202,7 +211,8 @@ extension Contact {
         agentTemplatePublishedURL: String? = nil,
         profileEmoji: String? = nil,
         agentInstanceId: String? = nil,
-        agentEmail: String? = nil
+        agentEmail: String? = nil,
+        agentPhone: String? = nil
     ) -> Contact {
         Contact(
             inboxId: inboxId,
@@ -219,7 +229,8 @@ extension Contact {
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
             agentInstanceId: agentInstanceId,
-            agentEmail: agentEmail
+            agentEmail: agentEmail,
+            agentPhone: agentPhone
         )
     }
 
@@ -243,7 +254,8 @@ extension Contact {
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
             agentInstanceId: agentInstanceId,
-            agentEmail: agentEmail
+            agentEmail: agentEmail,
+            agentPhone: agentPhone
         )
     }
 
@@ -267,7 +279,8 @@ extension Contact {
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
             agentInstanceId: agentInstanceId,
-            agentEmail: agentEmail
+            agentEmail: agentEmail,
+            agentPhone: agentPhone
         )
     }
 
@@ -295,7 +308,8 @@ extension Contact {
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
             agentInstanceId: agentInstanceId,
-            agentEmail: agentEmail
+            agentEmail: agentEmail,
+            agentPhone: agentPhone
         )
     }
 
@@ -319,7 +333,8 @@ extension Contact {
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
             agentInstanceId: agentInstanceId,
-            agentEmail: agentEmail
+            agentEmail: agentEmail,
+            agentPhone: agentPhone
         )
     }
 
@@ -341,6 +356,7 @@ extension Contact {
             profileEmoji: profileEmoji,
             agentInstanceId: agentInstanceId,
             agentEmail: agentEmail,
+            agentPhone: agentPhone,
             agentAttestation: agentAttestation
         )
     }
@@ -366,6 +382,32 @@ extension Contact {
             profileEmoji: profileEmoji,
             agentInstanceId: agentInstanceId,
             agentEmail: agentEmail,
+            agentPhone: agentPhone,
+            agentAttestation: agentAttestation
+        )
+    }
+
+    /// Returns a copy with `agentPhone` overlaid. Mirrors `with(agentEmail:)`:
+    /// the number comes from a live per-conversation member profile and is not
+    /// persisted on `DBContact`.
+    public func with(agentPhone: String?) -> Contact {
+        Contact(
+            inboxId: inboxId,
+            displayName: displayName,
+            avatarURL: avatarURL,
+            avatarSalt: avatarSalt,
+            avatarNonce: avatarNonce,
+            avatarKey: avatarKey,
+            addedAt: addedAt,
+            addedViaConversationId: addedViaConversationId,
+            isBlocked: isBlocked,
+            agentVerification: agentVerification,
+            agentTemplateId: agentTemplateId,
+            agentTemplatePublishedURL: agentTemplatePublishedURL,
+            profileEmoji: profileEmoji,
+            agentInstanceId: agentInstanceId,
+            agentEmail: agentEmail,
+            agentPhone: agentPhone,
             agentAttestation: agentAttestation
         )
     }
@@ -391,6 +433,7 @@ extension Contact {
             profileEmoji: profileEmoji,
             agentInstanceId: agentInstanceId,
             agentEmail: agentEmail,
+            agentPhone: agentPhone,
             agentAttestation: agentAttestation
         )
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
@@ -210,6 +210,7 @@ public struct Profile: Codable, Identifiable, Hashable, Sendable {
         static let publishedURLKey: String = "publishedUrl"
         static let instanceIdKey: String = "instanceId"
         static let emailKey: String = "email"
+        static let phoneKey: String = "phone"
         static let variantKey: String = "variant"
     }
 }
@@ -263,6 +264,19 @@ extension Profile {
     /// `agentTemplateId` above.
     public var agentEmail: String? {
         metadata?[Constant.emailKey]?.stringValue.flatMap { value in
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
+    /// The agent's SMS number in E.164, read from the agent's per-conversation
+    /// profile metadata. The assistants worker stamps `phone` onto the profile
+    /// when it provisions a number, so an agent that has never provisioned SMS
+    /// reads as nil, as do human members. Drives the Text row in the contact
+    /// card's Contact Info section. Empty / whitespace-only values are coerced
+    /// to nil, mirroring `agentEmail` above.
+    public var agentPhone: String? {
+        metadata?[Constant.phoneKey]?.stringValue.flatMap { value in
             let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmed.isEmpty ? nil : trimmed
         }


### PR DESCRIPTION
Targets `dev` so it can produce a Firebase build — `firebase-pr.yml` only fires for PRs based on `main` or `dev`. Add the `adhoc-build` label to trigger one.

The same change also exists as #1435 against Shane's prototype branch, for the ad-hoc build in #1341. This one is the standalone, mergeable version.

## What

The agent's SMS number now appears on its contact card, beside the email address that was already there. Tapping it opens Messages addressed to the agent; the copy control mirrors the email row.

## Why this is small

The number already existed and was simply invisible. The assistants worker has been stamping `phone` onto the agent's XMTP profile since it started provisioning numbers — exactly the way it stamps `email`, which iOS already read as `Profile.agentEmail`. Nothing on this side ever read the other key.

There is **no backend change here**. The number reaches the phone today; this only surfaces it.

## Changes

- `Profile.agentPhone` — reads `metadata["phone"]`, coercing empty/whitespace values to nil. A direct mirror of `agentEmail` directly above it.
- `Contact.agentPhone` + `with(agentPhone:)` — the same overlay plumbing `agentEmail` uses, applied before `with(agentAttestation:)` so that overlay stays last as its doc comment requires.
- Contact Info section — the email row was a single-channel view, so rather than clone it, it becomes one card parameterized by the channel it draws (the pattern `ContactCardMode` already uses). `sms:` gets the number stripped to digits and `+`, while the row keeps showing the readable form.

Rows are independent: an agent with only one provisioned channel shows only that row, and the section is omitted when there is neither, so the header never stands alone. `agentPhone` defaults to `nil` throughout, so no existing caller changes.

## Seeing it

The `Agent template with email and number` preview renders both rows in the Xcode canvas with no account and no provisioned agent. On a device or simulator build, the rows appear on any agent whose runtime has provisioned the channel.

## Testing

**Not built.** This was written in a Linux container with no Xcode, so it has had no compile, no SwiftLint, and no SwiftFormat. It was reviewed against the conventions in `CLAUDE.md`, and every construction site of the changed types was checked, but that is review rather than verification. CI here is the first real build.

Worth exercising once built:

- An agent with both channels — both rows, correct captions.
- An agent with SMS but no email, and the reverse — only the provisioned row appears.
- A human contact — no Contact Info section at all.
- Tapping the number opens Messages pre-addressed; tapping the address opens Mail.

## Related

Inbound texts are currently truncated to 80 characters before reaching the agent. That fix is server-side, on `claude/twilio-sms-convos-ha79jz` in `convos-assistants`, and is unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUV7w9MkMLRUfL4vek714Y)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790290931&installation_model_id=20076&pr_number=1436&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1436&signature=636045ec1e4f4f1aa648577b3dfa71f06f607c468157f4e11f6eb8e1d7adc708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent SMS number to contact card with copy and `sms:` open actions
> - Adds `agentPhone: String?` to the `Contact` model and reads it from profile metadata via `Profile.agentPhone`.
> - Introduces `ContactChannel` enum and `ContactDetailChannelCard` to render email and text rows; tapping text opens Messages with `sms:` using a sanitized number.
> - Replaces the email-only `ContactDetailEmailSection` with `ContactDetailContactInfoSection`, which renders when either email or phone is present.
> - Risk: `Contact.mock` and all `Contact.with(...)` overlay methods now require `agentPhone` propagation; any call site constructing a `Contact` directly must supply the new field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11fd34a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->