### PR TITLE
Add from Anywhere on the agent detail screen

### DIFF
--- a/Convos/Your Space/AgentReachSection.swift
+++ b/Convos/Your Space/AgentReachSection.swift
@@ -1,0 +1,319 @@
+import ConvosComposer
+import SwiftUI
+
+/// Which way of reaching an agent a row is showing.
+///
+/// One row view parameterized by the channel it draws, rather than a near-copy
+/// per channel. Mirrors the pattern `ContactCardMode` uses elsewhere.
+enum AgentReachChannel {
+    case text
+    case email
+
+    /// The caption under the value. Both name the action, not the medium, so
+    /// the two rows read as a pair.
+    var caption: String {
+        switch self {
+        case .text: return "Text"
+        case .email: return "Email"
+        }
+    }
+
+    /// The glyph in the row's badge, standing in for the app that owns the
+    /// channel the way the Space page uses the platform's own icons.
+    var symbolName: String {
+        switch self {
+        case .text: return "message.fill"
+        case .email: return "envelope.fill"
+        }
+    }
+
+    var badgeColor: Color {
+        switch self {
+        case .text: return .colorGreen
+        case .email: return .colorBlue
+        }
+    }
+
+    /// The scheme that reaches this channel from the value.
+    var urlScheme: String {
+        switch self {
+        case .text: return "sms:"
+        case .email: return "mailto:"
+        }
+    }
+
+    var identifierStem: String {
+        switch self {
+        case .text: return "agent-reach-text"
+        case .email: return "agent-reach-email"
+        }
+    }
+
+    var copyAccessibilityLabel: String {
+        switch self {
+        case .text: return "Copy phone number"
+        case .email: return "Copy email address"
+        }
+    }
+
+    func openAccessibilityLabel(agentName: String, value: String) -> String {
+        switch self {
+        case .text: return "Text \(agentName) at \(value)"
+        case .email: return "Email \(agentName) at \(value)"
+        }
+    }
+}
+
+/// How to reach one agent from outside Convos.
+///
+/// Ported from the Space template's Add from Anywhere page: the channels, then
+/// worked examples of what each kind of message does. The examples carry the
+/// part a bare address cannot teach -- that mailing the agent updates the
+/// group -- in a member's own words rather than as instructions.
+///
+/// A channel the runtime has not provisioned is absent rather than drawn
+/// empty, and the caller omits the section when there is neither: an address
+/// that receives nothing is worse than no row.
+struct AgentReachSection: View {
+    let agentName: String
+    let phone: String?
+    let email: String?
+
+    /// True when there is at least one channel to draw. The call site checks
+    /// this rather than nesting the whole section in an `if`.
+    var hasAnyChannel: Bool {
+        phone != nil || email != nil
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
+            header
+            channels
+            examples
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
+            Text("Add from Anywhere")
+                .font(.title3.weight(.bold))
+                .foregroundStyle(.colorTextPrimary)
+            Text("\(agentName) comes with its own number and address. Send it a message from any app and it updates the group, then says what changed.")
+                .font(.subheadline)
+                .foregroundStyle(.colorTextSecondary)
+        }
+    }
+
+    @ViewBuilder
+    private var channels: some View {
+        VStack(spacing: 0.0) {
+            if let phone {
+                AgentReachChannelRow(channel: .text, value: phone, agentName: agentName)
+            }
+            if phone != nil, email != nil {
+                Divider().padding(.leading, Constant.separatorInset)
+            }
+            if let email {
+                AgentReachChannelRow(channel: .email, value: email, agentName: agentName)
+            }
+        }
+        .background(
+            .colorBackgroundRaisedSecondary,
+            in: .rect(cornerRadius: DesignConstants.CornerRadius.medium)
+        )
+    }
+
+    private var examples: some View {
+        VStack(spacing: 0.0) {
+            AgentReachExampleRow(
+                message: "Here is my flight confirmation. All booked",
+                outcome: "Updates Notes"
+            )
+            Divider().padding(.leading, DesignConstants.Spacing.step4x)
+            AgentReachExampleRow(
+                message: "We changed the reservation to 8. Update the group",
+                outcome: "Updates Events"
+            )
+            Divider().padding(.leading, DesignConstants.Spacing.step4x)
+            AgentReachExampleRow(
+                message: "Can you text me the wifi for the office?",
+                outcome: "Replies to you directly"
+            )
+        }
+        .background(
+            .colorBackgroundRaisedSecondary,
+            in: .rect(cornerRadius: DesignConstants.CornerRadius.medium)
+        )
+    }
+
+    private enum Constant {
+        /// Aligns a separator with the value column rather than the badge, so
+        /// the badges read as one stack.
+        static let separatorInset: CGFloat = 62.0
+    }
+}
+
+/// One channel: a badge, the address, and a control that copies it.
+private struct AgentReachChannelRow: View {
+    let channel: AgentReachChannel
+    let value: String
+    let agentName: String
+
+    @Environment(\.openURL) private var openURL: OpenURLAction
+
+    var body: some View {
+        HStack(spacing: DesignConstants.Spacing.step3x) {
+            reachButton
+            AgentReachCopyButton(
+                value: value,
+                accessibilityLabel: channel.copyAccessibilityLabel,
+                identifier: "\(channel.identifierStem)-copy"
+            )
+        }
+        .padding(DesignConstants.Spacing.step4x)
+    }
+
+    private var reachButton: some View {
+        let openLabel: String = channel.openAccessibilityLabel(agentName: agentName, value: value)
+        let action = { open() }
+        return Button(action: action) {
+            HStack(spacing: DesignConstants.Spacing.step3x) {
+                AgentReachBadge(symbolName: channel.symbolName, tint: channel.badgeColor)
+                VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+                    Text(value)
+                        .font(.body)
+                        .foregroundStyle(.colorTextPrimary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Text(channel.caption)
+                        .font(.footnote)
+                        .foregroundStyle(.colorTextSecondary)
+                }
+                Spacer(minLength: 0.0)
+            }
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(openLabel)
+        .accessibilityIdentifier(channel.identifierStem)
+    }
+
+    /// `sms:` rejects the spaces and punctuation a number is displayed with, so
+    /// the scheme gets the dialable form while the row keeps the readable one.
+    /// A value the initializer still refuses opens nothing.
+    private var schemeValue: String {
+        switch channel {
+        case .email:
+            return value
+        case .text:
+            return value.filter { $0.isNumber || $0 == "+" }
+        }
+    }
+
+    private func open() {
+        guard let url = URL(string: "\(channel.urlScheme)\(schemeValue)") else { return }
+        openURL(url)
+    }
+}
+
+/// The channel's glyph on a tinted rounded square, in the shape of an app icon.
+private struct AgentReachBadge: View {
+    let symbolName: String
+    let tint: Color
+
+    var body: some View {
+        Image(systemName: symbolName)
+            .font(.footnote.weight(.semibold))
+            .foregroundStyle(Color.white)
+            .frame(width: Constant.size, height: Constant.size)
+            .background(tint, in: .rect(cornerRadius: Constant.cornerRadius))
+    }
+
+    private enum Constant {
+        static let size: CGFloat = 34.0
+        static let cornerRadius: CGFloat = 9.0
+    }
+}
+
+/// Copies one address and confirms in place.
+///
+/// Copying is the point of the row for anyone not holding this phone: a number
+/// read off a screen and retyped is where a digit goes missing. It confirms in
+/// the row rather than with a toast, because the row is the thing that changed.
+private struct AgentReachCopyButton: View {
+    let value: String
+    let accessibilityLabel: String
+    let identifier: String
+
+    @State private var didCopy: Bool = false
+
+    var body: some View {
+        let title: String = didCopy ? "Copied" : "Copy"
+        let background: Color = didCopy ? .colorGreen : .colorFillMinimal
+        let foreground: Color = didCopy ? .colorTextPrimaryInverted : .colorTextSecondary
+        let label: String = didCopy ? "Copied" : accessibilityLabel
+        let action = { copyToClipboard() }
+        return Button(action: action) {
+            Text(title)
+                .font(.footnote.weight(.bold))
+                .foregroundStyle(foreground)
+                .padding(.vertical, DesignConstants.Spacing.step2x)
+                .padding(.horizontal, DesignConstants.Spacing.step3x)
+                .background(background, in: .capsule)
+                .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+        .accessibilityIdentifier(identifier)
+    }
+
+    private func copyToClipboard() {
+        UIPasteboard.general.string = value
+        didCopy = true
+        Task {
+            try? await Task.sleep(nanoseconds: Constant.confirmationNanoseconds)
+            didCopy = false
+        }
+    }
+
+    private enum Constant {
+        static let confirmationNanoseconds: UInt64 = 1_400_000_000
+    }
+}
+
+/// One worked example: what a member sends, and what the agent does with it.
+private struct AgentReachExampleRow: View {
+    let message: String
+    let outcome: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+            Text("“\(message)”")
+                .font(.body)
+                .foregroundStyle(.colorTextPrimary)
+            Text(outcome)
+                .font(.footnote)
+                .foregroundStyle(.colorTextSecondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(DesignConstants.Spacing.step4x)
+    }
+}
+
+#Preview("Both channels") {
+    AgentReachSection(
+        agentName: "Maple",
+        phone: "+1 (615) 555-0142",
+        email: "maple.9f3ab2@ai.convos.org"
+    )
+    .padding()
+}
+
+#Preview("Text only") {
+    AgentReachSection(
+        agentName: "Maple",
+        phone: "+1 (615) 555-0142",
+        email: nil
+    )
+    .padding()
+}

--- a/Convos/Your Space/ManageAgentsView.swift
+++ b/Convos/Your Space/ManageAgentsView.swift
@@ -33,6 +33,12 @@ struct ManageAgentsView: View {
         let primaryConversationId: String?
         let agentInboxId: String?
         let providerRawValue: String?
+        /// The agent's SMS number, from its per-conversation profile metadata.
+        /// nil when the runtime has not provisioned one, which hides the Text row.
+        let phone: String?
+        /// The agent's email address, from the same metadata. nil hides the
+        /// Email row. An agent with neither has no Reach section at all.
+        let email: String?
 
         init(
             id: String,
@@ -51,7 +57,9 @@ struct ManageAgentsView: View {
             shareText: String = "Try this agent with me in Convos.",
             primaryConversationId: String? = nil,
             agentInboxId: String? = nil,
-            providerRawValue: String? = nil
+            providerRawValue: String? = nil,
+            phone: String? = nil,
+            email: String? = nil
         ) {
             self.id = id
             self.name = name
@@ -70,6 +78,8 @@ struct ManageAgentsView: View {
             self.primaryConversationId = primaryConversationId
             self.agentInboxId = agentInboxId
             self.providerRawValue = providerRawValue
+            self.phone = phone
+            self.email = email
         }
     }
 
@@ -181,6 +191,7 @@ private struct AgentAccessDetailView: View {
                 listeningReceipt
                 permissionReceipt
                 places
+                reachAnywhere
                 useAnywhere
             }
             .padding(.horizontal, DesignConstants.Spacing.step6x)
@@ -283,6 +294,21 @@ private struct AgentAccessDetailView: View {
         }
     }
 
+    /// How to reach this agent from outside Convos. Drawn only when the
+    /// runtime has provisioned at least one channel; an agent with neither
+    /// shows nothing rather than an empty heading.
+    @ViewBuilder
+    private var reachAnywhere: some View {
+        let section = AgentReachSection(
+            agentName: agent.name,
+            phone: agent.phone,
+            email: agent.email
+        )
+        if section.hasAnyChannel {
+            section
+        }
+    }
+
     private var useAnywhere: some View {
         ShareLink(item: agent.shareText) {
             Label("Share this agent anywhere", systemImage: "square.and.arrow.up")
@@ -339,7 +365,9 @@ private struct AgentAccessDetailView: View {
                         replyBehavior: "Responds on mention",
                         isListening: true
                     ),
-                ]
+                ],
+                phone: "+1 (615) 555-0142",
+                email: "quarters-planner.9f3ab2@ai.convos.org"
             ),
             .init(
                 id: "codex",

--- a/Convos/Your Space/YourSpaceView.swift
+++ b/Convos/Your Space/YourSpaceView.swift
@@ -1485,7 +1485,9 @@ private extension YourSpaceView {
                 places: places,
                 shareText: shareText,
                 primaryConversationId: sortedEntries.first?.conversation.id,
-                agentInboxId: first.agent.profile.inboxId
+                agentInboxId: first.agent.profile.inboxId,
+                phone: first.agent.profile.agentPhone,
+                email: first.agent.profile.agentEmail
             )
         }
         .sorted { lhs, rhs in

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
@@ -210,6 +210,7 @@ public struct Profile: Codable, Identifiable, Hashable, Sendable {
         static let publishedURLKey: String = "publishedUrl"
         static let instanceIdKey: String = "instanceId"
         static let emailKey: String = "email"
+        static let phoneKey: String = "phone"
         static let variantKey: String = "variant"
     }
 }
@@ -324,6 +325,18 @@ extension Profile {
     /// `agentTemplateId` above.
     public var agentEmail: String? {
         metadata?[Constant.emailKey]?.stringValue.flatMap { value in
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
+    /// The agent's SMS number in E.164, read from the agent's per-conversation
+    /// profile metadata. The assistants worker stamps `phone` onto the profile
+    /// when it provisions a number, exactly as it stamps `email`. nil for human
+    /// members and for agents whose runtime has not provisioned SMS. Empty /
+    /// whitespace-only values are coerced to nil, mirroring `agentEmail` above.
+    public var agentPhone: String? {
+        metadata?[Constant.phoneKey]?.stringValue.flatMap { value in
             let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmed.isEmpty ? nil : trimmed
         }


### PR DESCRIPTION
Targets `codex/shane-mac-do-not-merge-convos-strategy-reset` (#1433) and is based on its head, so it merges without conflict.

## What

Ports the Space template's **Add from Anywhere** page (convos-assistants #3495) into the native agent screen. Open Agents, pick an agent, and under Places there's now a section with the number and address that reach it from outside Convos — each with a copy control — followed by three worked examples of what a message to it actually does.

It sits above the existing "Share this agent anywhere" button, which is the other direction: that shares the agent *out*, this is how a message gets *in*.

## Why the examples are the point

A bare address doesn't tell anyone that mailing the agent updates the group. That's what #3495's page existed to teach, so the examples come across with it, phrased the way a member would type them rather than as instructions:

- "Here is my flight confirmation. All booked" → Updates Notes
- "We changed the reservation to 8. Update the group" → Updates Events
- "Can you text me the wifi for the office?" → Replies to you directly

## The channels are real

Not committed values. The assistants worker stamps `phone` and `email` onto the agent's XMTP profile when it provisions them — `agentEmail` was already read on this side, `phone` never was. `Profile.agentPhone` now reads it the same way, and `groupOwnedAgents` passes both through from the live member profile.

A channel the runtime hasn't provisioned is absent rather than drawn empty, and the whole section is omitted when there's neither — an address that receives nothing is worse than no row. Both `Agent` fields default to `nil`, so no existing construction site changes.

## Design notes

- One row view parameterized by its channel rather than a near-copy per channel, following the pattern `ContactCardMode` uses.
- #3495 uses the real Messages and Mail app icons. Here each row gets a tinted rounded-square badge with the matching SF Symbol — the same read, without shipping traced Apple artwork.
- Tapping a value hands it to the app that owns the channel. `sms:` gets the number stripped to digits and `+`, while the row keeps showing the readable form.
- Copy confirms in place, turning green for ~1.4s, because the row is the thing that changed.

## Testing

**Not built.** Written in a Linux container with no Xcode — no compile, no SwiftLint, no SwiftFormat. I checked what I could without a toolchain: `DesignConstants` resolves from `ConvosComposer` (not `ConvosCore`), `UIPasteboard` resolves under the same import set `JoinConversationView` already uses, every colour asset referenced exists in `Assets.xcassets`, and the app target uses `fileSystemSynchronizedGroups` so the new file needs no `project.pbxproj` change. CI here is the first real build.

The `Both channels` and `Text only` previews render the section in the Xcode canvas with no account and no provisioned agent. The `ManageAgentsView` preview's first agent also carries both channels now.

## Related

An agent that provisioned SMS before the profile carried a number won't show one: the stamp is best-effort and the provisioning workflow returns early once a number exists, so it never re-runs. Fixed separately on `claude/twilio-sms-convos-ha79jz` in `convos-assistants`, which needs to deploy before those agents populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUV7w9MkMLRUfL4vek714Y)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790294191&installation_model_id=20076&pr_number=1437&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1437&signature=07c0c051047c3a1707c2488f4537bba36392f04ff147392d6ae71c54b794c026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Add from Anywhere' reach section to agent detail screen
> - Adds `AgentReachSection` with tappable text/email rows that open `sms:` or `mailto:` URLs and copy buttons that flash 'Copied' for ~1.4 seconds.
> - Extends `ManageAgentsView.Agent` with optional `phone` and `email`, wired from `Profile.agentPhone` (new, reads metadata `"phone"`) and `Profile.agentEmail` in [YourSpaceView.swift](https://github.com/xmtplabs/convos-ios/pull/1437/files#diff-dddd2618f20ccb974b1927a457e249108300e67ea2048505604ac8154c4861da).
> - Section only renders when at least one channel exists, checked via `AgentReachSection.hasAnyChannel`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3dd4483. 4 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->