### PR TITLE
Make Connections v2 unconditional and stop per-conversation auto-enable

### DIFF
--- a/Convos/Abilities/AbilitiesServices.swift
+++ b/Convos/Abilities/AbilitiesServices.swift
@@ -31,16 +31,14 @@ struct AbilitiesSelection {
 }
 
 /// Process-wide accessor for the active abilities configuration backing
-/// the flag-gated V2 abilities surfaces (the App Settings abilities list
-/// and the per-conversation abilities section). One service instance
-/// app-wide so state changes carry across surfaces (connecting an ability
-/// in settings is immediately visible in conversation info).
+/// the abilities surfaces (the App Settings abilities list and the
+/// per-conversation abilities section). One service instance app-wide so
+/// state changes carry across surfaces (connecting an ability in settings
+/// is immediately visible in conversation info).
 ///
 /// `configure(...)` wires the live transport at app start; `useLiveBackend`
-/// (always true whenever `FeatureFlags.isAbilitiesV2Enabled` is on, see
-/// below) picks which pair `selection` serves. Previews and tests never
-/// call `configure`, so they fall back to the mock, mirroring
-/// `CreditsServices`.
+/// picks which pair `selection` serves. Previews and tests never call
+/// `configure`, so they fall back to the mock, mirroring `CreditsServices`.
 enum AbilitiesServices {
     /// Set once during `ConvosApp.init` before any surface can read them;
     /// the actor-based service handles its own concurrency.
@@ -160,25 +158,14 @@ enum AbilitiesServices {
         }
     }
 
-    /// Debug sub-toggle under the Abilities V2 flag: live backend versus
-    /// the in-memory mock. Coupled to `FeatureFlags.isAbilitiesV2Enabled` in
-    /// both directions so the two can never disagree: enabling V2 forces
-    /// this on (write-time, in the flag's setter); turning this off forces
-    /// V2 off (write-time, below). This getter also reports live whenever
-    /// V2 is on regardless of what is stored, so a combination saved before
-    /// this coupling existed self-heals on the next read instead of
-    /// resurfacing after a relaunch -- there is no user-visible control for
-    /// this flag on its own; the Debug menu exposes a single "Abilities v2"
-    /// toggle. Defaults to live; production always reads live (the stored
-    /// override is only writable from the Debug menu, which dev/local
-    /// builds alone can reach -- runtime-gated rather than `#if DEBUG` for
-    /// the same reason documented on `CreditsServices`).
+    /// Live backend versus the in-memory mock. Defaults to live; production
+    /// always reads live. The stored override currently has no UI writer;
+    /// non-production builds still honor a previously persisted value
+    /// (runtime-gated rather than `#if DEBUG` for the same reason
+    /// documented on `CreditsServices`).
     @MainActor
     static var useLiveBackend: Bool {
         guard !ConfigManager.shared.currentEnvironment.isProduction else { return true }
-        if FeatureFlags.shared.isAbilitiesV2Enabled {
-            return true
-        }
         if let stored = UserDefaults.standard.object(forKey: Constant.useLiveBackendKey) as? Bool {
             return stored
         }
@@ -189,9 +176,6 @@ enum AbilitiesServices {
     static func setUseLiveBackend(_ value: Bool) {
         guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
         UserDefaults.standard.set(value, forKey: Constant.useLiveBackendKey)
-        if !value {
-            FeatureFlags.shared.isAbilitiesV2Enabled = false
-        }
     }
 
     /// Debug sub-toggle for the V1 awareness shim (ProfileUpdate metadata

--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -250,52 +250,29 @@ struct AppSettingsView: View {
         }
     }
 
-    /// The V1 connections list, or the V2 abilities list behind the
-    /// Abilities V2 feature flag. Off by default in every environment;
-    /// reachable from the Debug menu in non-production builds and from the
-    /// curated prod debug menu in production. Read at push time, so
-    /// flipping the flag in either debug menu takes effect on the next
-    /// visit. The V2 branch presents `AbilitiesListScreen`, which owns its
-    /// view model via `@State`, so re-evaluations of this builder cannot
-    /// replace the model mid-push.
+    /// The abilities list. `AbilitiesListScreen` owns its view model via
+    /// `@State`, so re-evaluations of this builder cannot replace the model
+    /// mid-push.
     @ViewBuilder
     private var connectionsDestination: some View {
-        if FeatureFlags.shared.isAbilitiesV2Enabled {
-            AbilitiesListScreen(
-                selection: AbilitiesServices.selection,
-                mode: .appSettings,
-                usageSource: AbilitiesServices.connectionUsageSource
-            )
-        } else {
-            ConnectionsListView(viewModel: viewModel.connectionsListViewModel)
-        }
+        AbilitiesListScreen(
+            selection: AbilitiesServices.selection,
+            mode: .appSettings,
+            usageSource: AbilitiesServices.connectionUsageSource
+        )
     }
 
-    /// Row title and count follow `connectionsDestination`: "Abilities"
-    /// over the V2 list under the flag, "Connections" over the V1 list
-    /// otherwise. The count is V1 connections, so it only renders alongside
-    /// the V1 title.
     @ViewBuilder
     private var connectionsRowLabel: some View {
-        let isAbilitiesV2: Bool = FeatureFlags.shared.isAbilitiesV2Enabled
-        let title: String = "Connections"
-        let connectionsCount: Int = viewModel.connectionsListViewModel.connections.count
-        let showsCount: Bool = !isAbilitiesV2 && connectionsCount > 0
         HStack {
             Image(systemName: "batteryblock.fill")
                 .foregroundStyle(.colorTextPrimary)
                 .frame(width: DesignConstants.Spacing.step8x, alignment: .center)
 
-            Text(title)
+            Text("Connections")
                 .foregroundStyle(.colorTextPrimary)
 
             Spacer()
-
-            if showsCount {
-                Text("\(connectionsCount)")
-                    .foregroundStyle(.colorTextSecondary)
-                    .monospacedDigit()
-            }
         }
     }
 

--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -83,43 +83,6 @@ final class FeatureFlags {
         }
     }
 
-    /// Off by default -- gates the V2 abilities surfaces (the abilities
-    /// catalog list in App Settings and the per-conversation abilities
-    /// section), backed by the live abilities backend once enabled (see
-    /// `AbilitiesServices.useLiveBackend`, which reports live unconditionally
-    /// whenever this flag is on). Toggle from App Settings -> Debug in
-    /// non-production builds, or from the curated prod debug menu in
-    /// production. Deliberately not prod-locked like most flags above: the
-    /// control is reachable everywhere so V2 can be dogfooded in production,
-    /// same posture as `isXMTPBidiStreamsEnabled`. Default stays off in
-    /// every environment -- enabling it in production points the client at
-    /// whatever the production abilities backend currently serves, which may
-    /// lag what dev has.
-    ///
-    /// Coupled to `AbilitiesServices.useLiveBackend` in both directions so
-    /// V2 running against the mock (instead of the live backend) can never
-    /// be reached: turning this on forces the live backend on too
-    /// (write-time, below). `AbilitiesServices.useLiveBackend`'s getter
-    /// enforces the same invariant independent of what is in storage, which
-    /// is what actually keeps a value restored from persistence at launch
-    /// from resurfacing the invalid combination -- and in production that
-    /// getter reports live regardless of storage, so the coupling holds
-    /// there without needing a production guard of its own.
-    var isAbilitiesV2Enabled: Bool {
-        get {
-            access(keyPath: \.isAbilitiesV2Enabled)
-            return UserDefaults.standard.bool(forKey: Constant.abilitiesV2EnabledKey)
-        }
-        set {
-            withMutation(keyPath: \.isAbilitiesV2Enabled) {
-                UserDefaults.standard.set(newValue, forKey: Constant.abilitiesV2EnabledKey)
-            }
-            if newValue {
-                AbilitiesServices.setUseLiveBackend(true)
-            }
-        }
-    }
-
     /// Off by default -- gates the internal action that copies a Space share
     /// message to the clipboard so another conversation's agent can import
     /// the Space. Deliberately reachable in every environment; production
@@ -254,7 +217,6 @@ final class FeatureFlags {
         static let selectedAgentVariantKey: String = "featureFlags.selectedAgentVariant"
         static let agentVariantSelectorEnabledKey: String = "featureFlags.agentVariantSelectorEnabled"
         static let xmtpBidiStreamsEnabledKey: String = "featureFlags.xmtpBidiStreamsEnabled"
-        static let abilitiesV2EnabledKey: String = "featureFlags.abilitiesV2Enabled"
         static let spaceShareEnabledKey: String = "featureFlags.spaceShareEnabled"
         static let webInspectorEnabledKey: String = "featureFlags.webInspectorEnabled"
         static let agentRelayEnabledKey: String = "featureFlags.agentRelayEnabled"

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -73,8 +73,9 @@ struct FeatureRowItem<AccessoryView: View>: View {
 
 struct ConversationInfoView: View {
     /// Which agent-access section this view renders, latched once per view
-    /// lifetime from the Abilities V2 flag so a flag flip while the view
-    /// survives cannot switch rendering mid-flight.
+    /// lifetime so rendering cannot switch mid-flight. New presentations
+    /// always latch `abilitiesV2`; `connectionsV1` remains only for the
+    /// not-yet-deleted v1 surfaces.
     private enum AgentAccessMode {
         case abilitiesV2
         case connectionsV1
@@ -476,20 +477,12 @@ struct ConversationInfoView: View {
         }
     }
 
-    /// Latches the agent access mode from the Abilities V2 flag on first
-    /// run and creates that mode's view model. Rendering always follows
-    /// the latched mode, so a flag flip while this view identity survives
-    /// changes nothing until the next presentation.
+    /// Latches the agent access mode on first run and creates that mode's
+    /// view model. Rendering always follows the latched mode, so nothing
+    /// changes while this view identity survives.
     private func prepareAgentAccessViewModels() {
         guard viewModel.conversation.hasAgent else { return }
-        let mode: AgentAccessMode
-        if let agentAccessMode {
-            mode = agentAccessMode
-        } else if FeatureFlags.shared.isAbilitiesV2Enabled {
-            mode = .abilitiesV2
-        } else {
-            mode = .connectionsV1
-        }
+        let mode: AgentAccessMode = agentAccessMode ?? .abilitiesV2
         agentAccessMode = mode
         switch mode {
         case .abilitiesV2:

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1632,10 +1632,11 @@ private extension ConversationView {
     }
 
     /// The single host seam for the composer's connections capability: the
-    /// `+` menu row and the browser modal both feed from this one read. No
-    /// composer surface consults the flag directly.
+    /// `+` menu row and the browser modal both feed from this one read.
+    /// Which services a conversation can actually use is decided per
+    /// environment by the backend and agent runtime, not the client.
     var composerConnectionsEnabled: Bool {
-        FeatureFlags.shared.isAbilitiesV2Enabled
+        true
     }
 
     /// Powerplug tap from the `+` menu row: presents the Connections
@@ -2122,11 +2123,10 @@ private extension ConversationView {
         "\(viewModel.conversation.id)-\(viewModel.conversation.hasAgent)"
     }
 
-    /// Builds the escalation view model when the Abilities V2 flag is on
-    /// and the conversation has an agent. The flag is read once and latched
-    /// -- same posture as `ConversationInfoView.AgentAccessMode`. Runs from
-    /// a `.task` keyed on `escalationTaskKey`, so re-appearance restarts
-    /// stream observation and a conversation change rebuilds the model.
+    /// Builds the escalation view model when the conversation has an agent.
+    /// Runs from a `.task` keyed on `escalationTaskKey`, so re-appearance
+    /// restarts stream observation and a conversation change rebuilds the
+    /// model.
     func prepareEscalationIfNeeded() {
         if let escalationViewModel, escalationViewModel.conversationId != viewModel.conversation.id {
             escalationViewModel.stopObserving()
@@ -2136,8 +2136,7 @@ private extension ConversationView {
             escalationViewModel.startObserving()
             return
         }
-        guard FeatureFlags.shared.isAbilitiesV2Enabled,
-              viewModel.conversation.hasAgent else {
+        guard viewModel.conversation.hasAgent else {
             return
         }
         let escalation = ConversationEscalationViewModel(

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -257,16 +257,11 @@ struct ConvosApp: App {
     /// the surfaces refresh again on appear.
     private static func configureAbilities(session: any SessionManagerProtocol, environment: AppEnvironment) {
         AbilitiesServices.configure(session: session, environment: environment)
-        // Auto-enable mirrors the v1 connections toggle, so it runs exactly
-        // when that surface renders: whenever the abilities v2 flag is off.
-        // The flag is re-read on every agent add, so a debug-menu flip takes
-        // effect without a relaunch.
-        session.configureAutoEnableAbilities {
-            await MainActor.run { !FeatureFlags.shared.isAbilitiesV2Enabled }
-        }
-        if FeatureFlags.shared.isAbilitiesV2Enabled {
-            Task { await AbilitiesServices.refreshCatalogInBackground() }
-        }
+        // Auto-enable was the v1 connections behavior; leaving the service
+        // unconfigured keeps it disabled. Which services a conversation can
+        // use is decided per environment by the backend and agent runtime,
+        // not by the client enabling connections on every conversation.
+        Task { await AbilitiesServices.refreshCatalogInBackground() }
     }
 
     /// Tints the unselected tab items tertiary. The selected color is
@@ -356,12 +351,10 @@ struct ConvosApp: App {
             )
         }
 
-        // Abilities V2 foreground refresh: updates the live service's
+        // Abilities foreground refresh: updates the live service's
         // last-known catalog so the next screen-appear fetch merges against
-        // fresh state. No-op in mock mode or with the flag off.
-        if FeatureFlags.shared.isAbilitiesV2Enabled {
-            Task { await AbilitiesServices.refreshCatalogInBackground() }
-        }
+        // fresh state. No-op in mock mode.
+        Task { await AbilitiesServices.refreshCatalogInBackground() }
 
         // Messages the share extension wrote to the shared database from its
         // own process are invisible to this process's GRDB observation (it

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -115,27 +115,19 @@ struct DebugViewSection: View {
         Toggle("Agent variant selector", isOn: Bindable(FeatureFlags.shared).isAgentVariantSelectorEnabled)
     }
 
-    /// The Abilities V2 flag with its sub-toggles: the V1 awareness shim
-    /// (default off) and the mock consent flow (default off). There is
-    /// deliberately no separate mock/live backend toggle here -- enabling
-    /// V2 always enables the live backend (`FeatureFlags.isAbilitiesV2Enabled`
-    /// and `AbilitiesServices.useLiveBackend` are coupled in both directions
-    /// so that combination can't be split), so "Abilities v2" is the single
-    /// control for both. Sub-toggles only render while the flag is on; all
-    /// take effect on the next read (no relaunch needed).
+    /// Connections debug sub-toggles: the V1 awareness shim (default off)
+    /// and the mock consent flow (default off). Both take effect on the
+    /// next read (no relaunch needed).
     @ViewBuilder
     private var abilitiesFeatureToggles: some View {
-        Toggle("Connections v2", isOn: Bindable(FeatureFlags.shared).isAbilitiesV2Enabled)
-        if FeatureFlags.shared.isAbilitiesV2Enabled {
-            Toggle("Connections: v1 awareness shim", isOn: $abilitiesV1ShimEnabled)
-                .onChange(of: abilitiesV1ShimEnabled) { _, newValue in
-                    AbilitiesServices.setV1AwarenessShimEnabled(newValue)
-                }
-            Toggle("Connections: consent flow (mock)", isOn: $abilitiesEscalationMockEnabled)
-                .onChange(of: abilitiesEscalationMockEnabled) { _, newValue in
-                    AbilitiesServices.setEscalationMockEnabled(newValue)
-                }
-        }
+        Toggle("Connections: v1 awareness shim", isOn: $abilitiesV1ShimEnabled)
+            .onChange(of: abilitiesV1ShimEnabled) { _, newValue in
+                AbilitiesServices.setV1AwarenessShimEnabled(newValue)
+            }
+        Toggle("Connections: consent flow (mock)", isOn: $abilitiesEscalationMockEnabled)
+            .onChange(of: abilitiesEscalationMockEnabled) { _, newValue in
+                AbilitiesServices.setEscalationMockEnabled(newValue)
+            }
     }
 
     @ViewBuilder

--- a/Convos/Debug View/ProdDebugMenuView.swift
+++ b/Convos/Debug View/ProdDebugMenuView.swift
@@ -25,10 +25,6 @@ import UserNotifications
 //   install into a feature we are dogfooding in production:
 //   - the XMTP bidi streaming opt-in, which selects the stream transport at
 //     next launch -- nothing account- or network-mutating.
-//   - the Abilities v2 opt-in, which swaps the abilities catalog list and
-//     per-conversation section from the V1 connections UI to the V2 one and
-//     points them at the live abilities backend. Off by default; nothing
-//     mutates until a tester connects an ability from that surface.
 //   - the Web inspector opt-in, which only decides whether the space/browser
 //     web views set `isInspectable`. Off by default; it mutates nothing and
 //     merely lets Safari Web Inspector attach to debug the window.convos bridge.
@@ -182,7 +178,6 @@ struct ProdDebugMenuView: View {
             // The interactive controls in this curated menu; see the
             // module overview for why they are allowed here.
             Toggle("XMTP bidi streaming (applies next launch)", isOn: Bindable(FeatureFlags.shared).isXMTPBidiStreamsEnabled)
-            Toggle("Abilities v2", isOn: Bindable(FeatureFlags.shared).isAbilitiesV2Enabled)
             Toggle("Enable Relay (BYOA)", isOn: Bindable(FeatureFlags.shared).agentRelayEnabled)
             Toggle("Share Space (copy import link)", isOn: Bindable(FeatureFlags.shared).isSpaceShareEnabled)
             Toggle("Web inspector (space/browser web views)", isOn: Bindable(FeatureFlags.shared).isWebInspectorEnabled)

--- a/ConvosTests/FeatureFlagsObservationTests.swift
+++ b/ConvosTests/FeatureFlagsObservationTests.swift
@@ -6,8 +6,7 @@ import XCTest
 /// accessor registers with the observation registrar by hand. These tests
 /// pin that wiring: a view that reads a flag in its body must be
 /// invalidated the moment the flag is toggled. The debug menu's dependent
-/// rows (for example the abilities sub-toggles) rely on this to appear
-/// without leaving and re-entering the screen.
+/// rows rely on this to appear without leaving and re-entering the screen.
 @MainActor
 final class FeatureFlagsObservationTests: XCTestCase {
     func testSpaceShareDefaultsOffPersistsAndNotifiesObservers() {
@@ -37,23 +36,6 @@ final class FeatureFlagsObservationTests: XCTestCase {
         wait(for: [changed], timeout: 1.0)
         XCTAssertTrue(defaults.bool(forKey: key))
         XCTAssertTrue(flags.isSpaceShareEnabled)
-    }
-
-    func testTogglingAbilitiesV2NotifiesObservers() {
-        let flags = FeatureFlags.shared
-        let initial = flags.isAbilitiesV2Enabled
-        defer { flags.isAbilitiesV2Enabled = initial }
-
-        let changed = expectation(description: "abilities flag observation fired")
-        withObservationTracking {
-            _ = flags.isAbilitiesV2Enabled
-        } onChange: {
-            changed.fulfill()
-        }
-
-        flags.isAbilitiesV2Enabled = !initial
-        wait(for: [changed], timeout: 1.0)
-        XCTAssertEqual(flags.isAbilitiesV2Enabled, !initial)
     }
 
     func testTogglingBidiStreamsNotifiesObservers() {


### PR DESCRIPTION
Part of the calendar-only Connections v2 prod rollout (three PRs: agent runtime xmtplabs/convos-assistants#3621, a backend catalog allowlist PR, and this one).

## What

- **Remove the `isAbilitiesV2Enabled` feature flag.** The abilities surfaces (App Settings list, per-conversation section, composer connections row, escalation observer) render unconditionally; the "Connections v2" / "Abilities v2" toggles are gone from both debug menus. Which services a conversation can actually use is decided per environment by the backend catalog and the agent runtime's approval-card allowlist (`CONNECTIONS_ENABLED_SERVICES`, prod = calendar), not by a client flag.
- **Stop configuring `AutoEnableAbilitiesService`** — the v1 behavior of enabling connections on every conversation is off (an unconfigured service treats itself as disabled, fail-safe).
- `useLiveBackend` keeps its dev-only stored override but no longer couples to the removed flag; production always reads live.

## Why exec keeps working without auto-enable

Approving a capability card POSTs `/v2/connections/grants`, and the backend writes ConnectionGrant + AbilityEntitlement + ConversationAbility in one transaction — exactly the rows `checkEntitlement` reads. Auto-enable was a second independent caller of the same endpoint, not a dependency.

## Ordering

The backend catalog-allowlist PR should land in the same release train: until it deploys, prod catalogs still list non-calendar services, which this build would render (requests for them are already refused runtime-side by #3621).

## Not in this PR (follow-up cleanup)

Dead-but-compiling v1 surfaces: the `ConnectionsListView` path in settings, the `connectionsV1` agent-access mode, `AutoEnableAbilitiesService` itself.

## Verification

- `xcodebuild` (Convos (Dev)) clean; ConvosCore suite **1962 tests / 261 suites, 0 failures**.
- Repo-wide sweep: zero references to the removed flag/key; `configureAutoEnableAbilities` has zero callers.
- SwiftLint/SwiftFormat clean (pre-commit hooks).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790326012&installation_model_id=20076&pr_number=1441&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1441&signature=e437573d90f9ad1b0a65b8712c95c6212fdc6c6f04da4c6b11045de363322219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make Connections v2 unconditional and remove `isAbilitiesV2Enabled` flag
> - Removes the `isAbilitiesV2Enabled` computed property and its UserDefaults key from [FeatureFlags.swift](https://github.com/xmtplabs/convos-ios/pull/1441/files#diff-9e8aa9971f330243a3592cb6d2c4793ba683385e20db0ff00777e56f02272f7c), and deletes all read sites across abilities services, conversation views, and app lifecycle handlers.
> - The Connections row in [AppSettingsView.swift](https://github.com/xmtplabs/convos-ios/pull/1441/files#diff-30e98d39613710cf0f912b477ed30a8638995959caa9cb2e9facdc10e1c3f8b9) now always navigates to `AbilitiesListScreen` with a fixed title and no count badge.
> - `ConversationInfoView` and `ConversationView` always select the abilities-based agent access mode and always start escalation observation for agent conversations.
> - `AbilitiesServices.useLiveBackend` and `setUseLiveBackend` no longer couple to the removed flag; live backend selection honors only the persisted override (non-production) or always returns true (production).
> - `ConvosApp` always schedules abilities catalog refresh on startup and foreground, replacing the legacy auto-enable logic.
> - Debug menus in [DebugView.swift](https://github.com/xmtplabs/convos-ios/pull/1441/files#diff-c45ca903f9cc34fa316deb294404f56695ab7914c8a43563ade3081b646368aa) and [ProdDebugMenuView.swift](https://github.com/xmtplabs/convos-ios/pull/1441/files#diff-815af3105d8d852a87268252db30020c7003096279ca94a9c908613d1bb26cef) drop the top-level toggle; sub-toggles for the v1 awareness shim and mock consent flow remain.
> - Behavioral Change: `AgentAccessMode` now defaults to `.abilitiesV2` for new conversations with an agent, and the v1 `ConnectionsListView` path is no longer reachable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b36e98.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->