### PR TITLE
Add diagnostics to the prod debug menu entry chain

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -469,7 +469,11 @@ struct AppSettingsView: View {
         // gesture only matters in production where the curated menu is opt-in.
         // Read the persisted flag directly (not a cached copy) so a menu that
         // was disabled elsewhere can be re-enabled without relaunching.
-        guard environment.isProduction, !DebugMenuFlagStore.isEnabled() else { return }
+        guard environment.isProduction else { return }
+        if DebugMenuFlagStore.isEnabled() {
+            Log.info("Version tap ignored: debug menu flag already enabled")
+            return
+        }
         let now = Date()
         if let lastTap = lastVersionTapAt, now.timeIntervalSince(lastTap) > Constant.versionTapWindow {
             versionTapCount = 0
@@ -478,6 +482,7 @@ struct AppSettingsView: View {
         versionTapCount += 1
         if versionTapCount >= Constant.versionTapThreshold {
             versionTapCount = 0
+            Log.info("Version-tap threshold reached; presenting enable-debug-menu prompt")
             showingEnableDebugConfirmation = true
         }
     }

--- a/Convos/Debug View/DebugMenuFlagStore.swift
+++ b/Convos/Debug View/DebugMenuFlagStore.swift
@@ -27,6 +27,7 @@ enum DebugMenuFlagStore {
 
     static func setEnabled(_ enabled: Bool) {
         UserDefaults.standard.set(enabled, forKey: Constant.enabledKey)
+        Log.info("DebugMenuFlagStore: setEnabled(\(enabled)), readback=\(isEnabled())")
     }
 
     private enum Constant {


### PR DESCRIPTION
A field report says the prod debug menu no longer appears: the 7-tap version gesture shows the unlock prompt, but the menu row then never renders, surviving relaunch.

The bug does not reproduce on dev tip: the full chain (tap threshold, prompt, enable, row render, screen push, relaunch persistence) passes in a genuine production AppEnvironment on iOS 26.2/26.5 under both -Onone and -O, with a negative control. The chain is unchanged since it shipped, every 2.6.0 TestFlight slot contains the identical chain and UserDefaults key, and nothing in the codebase clears the persisted flag — so the failure is a device/runtime condition.

This PR adds targeted diagnostics so one exported log from an affected device pinpoints the failing stage:
- `DebugMenuFlagStore.setEnabled` logs the write and reads the persisted value back, logging a mismatch loudly.
- The version-tap gesture logs threshold hits and ignored taps.
All in the exportable app-group log (the Logs export works even without the menu). With this build, a single repro distinguishes: enable never ran vs write not persisted vs render failed.

The non-reactive row gate found during the investigation is fixed separately in the follow-up PR.

Verified: build clean, SwiftLint --strict clean; app-target only.