### PR TITLE
feat(agents): read the model an agent runs on from synced group state

### DIFF
--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -382,6 +382,7 @@ struct ContactDetailView: View {
                     contactDisplayName: contact.resolvedDisplayName,
                     agentEmail: contact.agentEmail,
                     agentInstanceId: contact.agentInstanceId,
+                    agentModelService: agentModelService,
                     // The displayed agent's own variant first: an agent built
                     // on a variant worker exists only there, so routing its
                     // switch by whatever the global selector happens to hold
@@ -626,6 +627,20 @@ struct ContactDetailView: View {
     /// want a different chat, so falling through to the picker is the
     /// right move. Multiple 1:1s with the same person are allowed; the
     /// SQL ordering picks the most-recently-active alternative.
+    /// The picker's write path, when this detail is open inside a conversation
+    /// with the agent. Writing the pick into that conversation's appData from
+    /// this device is what puts the picking member's name on the transcript row
+    /// — the Assistant Worker signs its own commits, so a switch it publishes
+    /// reads as the agent having switched itself.
+    private var agentModelService: (any AgentModelServing)? {
+        guard let session, let conversationId = mode.conversationId else { return nil }
+        return ConversationAppDataAgentModelService(
+            metadataWriter: session.messagingService().conversationMetadataWriter(),
+            conversationId: conversationId,
+            agentInboxId: contact.inboxId
+        )
+    }
+
     private func findExistingOneToOne(session: any SessionManagerProtocol) -> Conversation? {
         try? session
             .conversationsRepository(for: [.allowed, .unknown])
@@ -876,6 +891,11 @@ private struct ContactDetailActions: View {
     /// Always plumbed through when the contact has one. Display gate
     /// is `showsInstanceIdRow`, not nullability of this field.
     let agentInstanceId: String?
+    /// Writes a pick into this conversation's appData before mirroring it to
+    /// the control plane, so the transcript row carries the picking member's
+    /// name rather than the agent's. Nil outside a conversation, where there is
+    /// no appData to write into and the Worker's own publish carries the switch.
+    let agentModelService: (any AgentModelServing)?
     /// Dev-only variant routing key for the model picker. An agent built on a
     /// variant worker only exists there, so a switch that omits this lands on
     /// the default worker and changes nothing. Nil (and stripped in
@@ -915,7 +935,8 @@ private struct ContactDetailActions: View {
                 ContactDetailModelRow(
                     contactDisplayName: contactDisplayName,
                     instanceId: agentInstanceId,
-                    variantId: agentVariantId
+                    variantId: agentVariantId,
+                    service: agentModelService
                 )
             }
             if showShare {
@@ -1066,12 +1087,19 @@ private struct ContactDetailModelRow: View {
 
     @State private var store: AgentModelStore
 
-    init(contactDisplayName: String, instanceId: String, variantId: String?) {
+    init(
+        contactDisplayName: String,
+        instanceId: String,
+        variantId: String?,
+        service: (any AgentModelServing)?
+    ) {
         self.contactDisplayName = contactDisplayName
         self.instanceId = instanceId
         self.variantId = variantId
         _store = State(
-            wrappedValue: AgentModelStore(instanceId: instanceId, variantId: variantId)
+            wrappedValue: service.map {
+                AgentModelStore(instanceId: instanceId, variantId: variantId, service: $0)
+            } ?? AgentModelStore(instanceId: instanceId, variantId: variantId)
         )
     }
 

--- a/ConvosAppData/Sources/ConvosAppData/Proto/conversation_custom_metadata.pb.swift
+++ b/ConvosAppData/Sources/ConvosAppData/Proto/conversation_custom_metadata.pb.swift
@@ -275,6 +275,28 @@ public nonisolated struct ConversationProfile: Sendable {
   /// Clears the value of `connections`. Subsequent reads from it will return its default value.
   public mutating func clearConnections() {self._connections = nil}
 
+  /// The model this agent runs on, for a profile that belongs to one. Absent
+  /// for a human member, and absent for an agent nobody has switched — which
+  /// is not the same as a model: an unswitched agent runs whatever its own
+  /// template shipped, and only the agent knows what that is.
+  ///
+  /// It hangs off the profile rather than off the conversation because the
+  /// choice belongs to one agent, which is exactly what participationMode is
+  /// not: a room holding several agents carries one entry each.
+  ///
+  /// The Assistant Worker is the sole authority. An agent only runs what its
+  /// own catalogue lists, so a choice is validated and applied before it is
+  /// published here; clients read this copy to see what every member's agent
+  /// was switched to, and never write it.
+  public var model: String {
+    get {_model ?? String()}
+    set {_model = newValue}
+  }
+  /// Returns true if `model` has been explicitly set.
+  public var hasModel: Bool {self._model != nil}
+  /// Clears the value of `model`. Subsequent reads from it will return its default value.
+  public mutating func clearModel() {self._model = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -283,6 +305,7 @@ public nonisolated struct ConversationProfile: Sendable {
   fileprivate var _image: String? = nil
   fileprivate var _encryptedImage: EncryptedImageRef? = nil
   fileprivate var _connections: String? = nil
+  fileprivate var _model: String? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -441,7 +464,7 @@ nonisolated extension EncryptedImageRef: SwiftProtobuf.Message, SwiftProtobuf._M
 
 nonisolated extension ConversationProfile: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = "ConversationProfile"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}inboxId\0\u{1}name\0\u{1}image\0\u{1}encryptedImage\0\u{1}connections\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}inboxId\0\u{1}name\0\u{1}image\0\u{1}encryptedImage\0\u{1}connections\0\u{1}model\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -454,6 +477,7 @@ nonisolated extension ConversationProfile: SwiftProtobuf.Message, SwiftProtobuf.
       case 3: try { try decoder.decodeSingularStringField(value: &self._image) }()
       case 4: try { try decoder.decodeSingularMessageField(value: &self._encryptedImage) }()
       case 5: try { try decoder.decodeSingularStringField(value: &self._connections) }()
+      case 6: try { try decoder.decodeSingularStringField(value: &self._model) }()
       default: break
       }
     }
@@ -479,6 +503,9 @@ nonisolated extension ConversationProfile: SwiftProtobuf.Message, SwiftProtobuf.
     try { if let v = self._connections {
       try visitor.visitSingularStringField(value: v, fieldNumber: 5)
     } }()
+    try { if let v = self._model {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 6)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -488,6 +515,7 @@ nonisolated extension ConversationProfile: SwiftProtobuf.Message, SwiftProtobuf.
     if lhs._image != rhs._image {return false}
     if lhs._encryptedImage != rhs._encryptedImage {return false}
     if lhs._connections != rhs._connections {return false}
+    if lhs._model != rhs._model {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/ConvosAppData/Sources/ConvosAppData/Proto/conversation_custom_metadata.proto
+++ b/ConvosAppData/Sources/ConvosAppData/Proto/conversation_custom_metadata.proto
@@ -73,4 +73,18 @@ message ConversationProfile {
     // now; no client reads or writes this field anymore. Kept defined so the
     // field number stays claimed and payloads from older releases keep decoding.
     optional string connections = 5;
+    // The model this agent runs on, for a profile that belongs to one. Absent
+    // for a human member, and absent for an agent nobody has switched — which
+    // is not the same as a model: an unswitched agent runs whatever its own
+    // template shipped, and only the agent knows what that is.
+    //
+    // It hangs off the profile rather than off the conversation because the
+    // choice belongs to one agent, which is exactly what participationMode is
+    // not: a room holding several agents carries one entry each.
+    //
+    // The Assistant Worker is the sole authority. An agent only runs what its
+    // own catalogue lists, so a choice is validated and applied before it is
+    // published here; clients read this copy to see what every member's agent
+    // was switched to, and never write it.
+    optional string model = 6;
 }

--- a/ConvosAppData/Sources/ConvosAppData/Proto/conversation_custom_metadata.proto
+++ b/ConvosAppData/Sources/ConvosAppData/Proto/conversation_custom_metadata.proto
@@ -82,9 +82,12 @@ message ConversationProfile {
     // choice belongs to one agent, which is exactly what participationMode is
     // not: a room holding several agents carries one entry each.
     //
-    // The Assistant Worker is the sole authority. An agent only runs what its
-    // own catalogue lists, so a choice is validated and applied before it is
-    // published here; clients read this copy to see what every member's agent
-    // was switched to, and never write it.
+    // Written by the member who picks it, the way participationMode is, so the
+    // commit carries that member's name into the transcript rather than the
+    // agent's. The Assistant Worker remains the value's authority: an agent
+    // only runs what its own catalogue lists, so a choice is validated and
+    // applied on its side, and the Worker republishes here whenever its row
+    // moves — a refused model rolled back, one dropped from the catalogue, or
+    // one chosen before the agent had a conversation to publish into.
     optional string model = 6;
 }

--- a/ConvosAppData/Tests/ConvosAppDataTests/AppDataTests.swift
+++ b/ConvosAppData/Tests/ConvosAppDataTests/AppDataTests.swift
@@ -138,6 +138,60 @@ struct SerializationTests {
         #expect(decoded.hasSpaceURL == true)
         #expect(decoded.spaceURL == url)
     }
+
+    @Test("Agent model decodes from the blob Herald actually writes")
+    func agentModelDecodesFromHeraldBlob() throws {
+        // Not hand-built: this is the exact output of the Assistant stack's
+        // own writer for one agent switched to a model, captured verbatim. A
+        // hand-rolled blob could encode the field the same wrong way this
+        // client decodes it and the test would still pass; a fixture from the
+        // other side of the wire cannot.
+        let blob = "CgF0EkMKIAARIjNEVWZ3iJkAESIzRFVmd4iZABEiM0RVZneImQAREgRBcmlhMhlhbnRocm9waWMvY2xhdWRlLXNvbm5ldC01"
+
+        let decoded = try ConversationCustomMetadata.fromCompactString(blob)
+
+        let profile = try #require(decoded.profiles.first)
+        #expect(profile.hasModel == true)
+        #expect(profile.model == "anthropic/claude-sonnet-5")
+        // The rest of the profile has to survive the splice that put the model
+        // there, since that splice rewrites the whole submessage.
+        #expect(profile.name == "Aria")
+        #expect(
+            profile.inboxIdString
+                == "0011223344556677889900112233445566778899001122334455667788990011"
+        )
+    }
+
+    @Test("Agent model survives an unrelated read-modify-write")
+    func agentModelSurvivesReadModifyWrite() throws {
+        var profile = ConversationProfile()
+        profile.inboxID = Data(repeating: 0x11, count: 32)
+        profile.model = "anthropic/claude-sonnet-5"
+        var metadata = ConversationCustomMetadata()
+        metadata.profiles = [profile]
+
+        var reloaded = try ConversationCustomMetadata.fromCompactString(metadata.toCompactString())
+        reloaded.emoji = "🛰️"
+        let decoded = try ConversationCustomMetadata.fromCompactString(reloaded.toCompactString())
+
+        #expect(decoded.profiles.first?.model == "anthropic/claude-sonnet-5")
+        #expect(decoded.emoji == "🛰️")
+    }
+
+    @Test("A profile with no model is not a profile on an empty model")
+    func absentAgentModelIsDistinctFromEmpty() throws {
+        var profile = ConversationProfile()
+        profile.inboxID = Data(repeating: 0x11, count: 32)
+        var metadata = ConversationCustomMetadata()
+        metadata.profiles = [profile]
+
+        let decoded = try ConversationCustomMetadata.fromCompactString(metadata.toCompactString())
+
+        // An agent nobody has switched runs its own template default, and only
+        // the agent knows what that is. Reading absent as "" would let a client
+        // claim it knows.
+        #expect(decoded.profiles.first?.hasModel == false)
+    }
 }
 
 @Suite("ConversationProfile Tests")

--- a/ConvosCore/Sources/ConvosComposer/AgentModelStore.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentModelStore.swift
@@ -157,6 +157,23 @@ public final class AgentModelStore {
         return options.first { $0.id == selectedId }?.name ?? selectedId
     }
 
+    /// Adopts a model that arrived over the network — someone switched this
+    /// agent on another device and the synced conversation carries their value.
+    ///
+    /// The counterpart of `AgentParticipationStore.apply(syncedLevel:)`, and
+    /// ignored under the same condition: a write outstanding on this device is
+    /// newer than anything the sync can be carrying, and this device's own
+    /// change arrives back here as a synced value a moment later anyway.
+    ///
+    /// Does not touch `options`. The catalogue is what this agent *can* run and
+    /// lives in its container; only the choice travels in group state.
+    public func apply(syncedModel: String?) {
+        hasLoaded = true
+        guard writesInFlight == 0 else { return }
+        confirmedId = syncedModel
+        selectedId = syncedModel
+    }
+
     /// Reads the agent's model and catalogue. Safe to call on every appearance.
     public func load() async {
         let generation = writeGeneration

--- a/ConvosCore/Sources/ConvosComposer/AgentModelStore.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentModelStore.swift
@@ -145,11 +145,46 @@ public struct ConversationAppDataAgentModelService: AgentModelServing {
         } catch {
             Log.warning("agent model appData write failed: \(error)")
         }
-        return try await controlPlane.writeModel(
-            model,
-            instanceId: instanceId,
-            variantId: variantId
-        )
+        do {
+            return try await controlPlane.writeModel(
+                model,
+                instanceId: instanceId,
+                variantId: variantId
+            )
+        } catch {
+            // The room is now naming a model the agent may never have been put
+            // on. A refusal the Worker saw it rolls back and republishes
+            // itself, but a call that never reached it leaves nothing to do
+            // that — so put back whatever the control plane still holds.
+            await restoreAppDataFromControlPlane(
+                instanceId: instanceId,
+                variantId: variantId
+            )
+            throw error
+        }
+    }
+
+    /// Re-writes appData from the model the control plane reports, after a
+    /// failed write left the room naming something else. Best-effort by
+    /// nature: it is repairing a write that already failed once, and the
+    /// Worker republishes on its own whenever its row moves.
+    private func restoreAppDataFromControlPlane(
+        instanceId: String,
+        variantId: String?
+    ) async {
+        do {
+            let snapshot = try await controlPlane.readModel(
+                instanceId: instanceId,
+                variantId: variantId
+            )
+            try await metadataWriter.updateAgentModel(
+                snapshot.model,
+                forAgent: agentInboxId,
+                in: conversationId
+            )
+        } catch {
+            Log.warning("agent model appData restore failed: \(error)")
+        }
     }
 }
 

--- a/ConvosCore/Sources/ConvosComposer/AgentModelStore.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentModelStore.swift
@@ -89,6 +89,70 @@ public struct ControlPlaneAgentModelService: AgentModelServing {
     }
 }
 
+/// Writes the pick into the group's appData from the picking member's device,
+/// then mirrors it to the control plane.
+///
+/// The order and the split both matter. The Assistant Worker signs its own
+/// commits, so a model it publishes reads in the transcript as the agent having
+/// switched itself; written from here, the row carries the name of the member
+/// who actually chose it — the same reason the participation mode is written
+/// client-side. The control plane still owns the value: it validates the choice
+/// against the agent's own catalogue, applies it to the runtime, and
+/// republishes into appData whenever its row moves, so a refused model is
+/// rolled back for everyone rather than left standing here.
+///
+/// The appData write is best-effort. A member whose commit fails still gets the
+/// switch, because the control-plane call is the one that changes what the
+/// agent runs; the Worker's own publish is what carries it to the room.
+public struct ConversationAppDataAgentModelService: AgentModelServing {
+    private let metadataWriter: any ConversationMetadataWriterProtocol
+    private let conversationId: String
+    private let agentInboxId: String
+    private let controlPlane: any AgentModelServing
+
+    public init(
+        metadataWriter: any ConversationMetadataWriterProtocol,
+        conversationId: String,
+        agentInboxId: String,
+        controlPlane: any AgentModelServing = ControlPlaneAgentModelService()
+    ) {
+        self.metadataWriter = metadataWriter
+        self.conversationId = conversationId
+        self.agentInboxId = agentInboxId
+        self.controlPlane = controlPlane
+    }
+
+    public func readModel(
+        instanceId: String,
+        variantId: String?
+    ) async throws -> AgentModelSnapshot {
+        // Read from the control plane, not from appData: the picker needs the
+        // catalogue too, and only the agent can name what it can run.
+        try await controlPlane.readModel(instanceId: instanceId, variantId: variantId)
+    }
+
+    public func writeModel(
+        _ model: String,
+        instanceId: String,
+        variantId: String?
+    ) async throws -> AgentModelSnapshot {
+        do {
+            try await metadataWriter.updateAgentModel(
+                model,
+                forAgent: agentInboxId,
+                in: conversationId
+            )
+        } catch {
+            Log.warning("agent model appData write failed: \(error)")
+        }
+        return try await controlPlane.writeModel(
+            model,
+            instanceId: instanceId,
+            variantId: variantId
+        )
+    }
+}
+
 /// Owns one agent's model for the picker that renders it.
 ///
 /// Same shape as `AgentParticipationStore`, and for the same reasons: a tap has

--- a/ConvosCore/Sources/ConvosComposer/AgentModelStore.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentModelStore.swift
@@ -137,6 +137,13 @@ public final class AgentModelStore {
     /// the order the member tapped in is the order the server sees.
     private var writeChain: Task<Void, Never>?
 
+    /// The newest synced value that arrived while a write was outstanding, held
+    /// so a failed write can roll back to it instead of to the older value the
+    /// server acknowledged before the sync. Double-optional on purpose: the
+    /// outer nil means "nothing arrived", the inner nil means "the room says no
+    /// model", and those are different answers.
+    private var deferredSyncedModel: String??
+
     public init(
         instanceId: String,
         variantId: String? = nil,
@@ -169,7 +176,15 @@ public final class AgentModelStore {
     /// lives in its container; only the choice travels in group state.
     public func apply(syncedModel: String?) {
         hasLoaded = true
-        guard writesInFlight == 0 else { return }
+        guard writesInFlight == 0 else {
+            // Held, not discarded. If the write now in flight fails it rolls
+            // back to what the server last acknowledged — and without this the
+            // rollback would restore a model the room has since moved off,
+            // leaving the picker on a value nothing will correct.
+            deferredSyncedModel = .some(syncedModel)
+            return
+        }
+        deferredSyncedModel = nil
         confirmedId = syncedModel
         selectedId = syncedModel
     }
@@ -232,15 +247,23 @@ public final class AgentModelStore {
             )
             if !snapshot.available.isEmpty { options = snapshot.available }
             confirmedId = option.id
+            // This tap is what the server holds now, so anything that synced
+            // while it was in flight is older than it and must not survive to
+            // be restored by a later rollback.
+            deferredSyncedModel = nil
             Log.info("agent model set to \(option.id)")
         } catch {
             Log.error("agent model update failed: \(error)")
             // Roll back only while this is still the newest tap — a newer one
             // already owns what the picker shows.
             guard writeGeneration == generation else { return }
-            selectedId = previous
-            confirmedId = previous
-            let previousName = previous.map { id in
+            // A synced value that landed while this write was out is newer than
+            // what the server acknowledged before it, so it wins the rollback.
+            let target = deferredSyncedModel ?? previous
+            deferredSyncedModel = nil
+            selectedId = target
+            confirmedId = target
+            let previousName = target.map { id in
                 options.first { $0.id == id }?.name ?? id
             }
             errorMessage = previousName.map {

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
@@ -116,9 +116,16 @@ extension XMTPiOS.Group {
     /// Read-only. The Assistant Worker validates a choice against that agent's
     /// own catalogue and publishes it; a client writing here would broadcast a
     /// model the agent may refuse.
-    public var agentModels: [String: String] {
+    /// Nil means the appData said nothing about models, which is not the same as
+    /// saying there are none. `currentCustomMetadata` turns an unreadable blob
+    /// into empty metadata rather than throwing, so an empty profile list is
+    /// indistinguishable from a failed read — and the models hang off those
+    /// profiles, so with none present this carries no information either way.
+    /// Callers must preserve what they already hold rather than clear it.
+    public var agentModels: [String: String]? {
         get throws {
             let metadata = try currentCustomMetadata
+            guard !metadata.profiles.isEmpty else { return nil }
             return metadata.profiles.reduce(into: [:]) { models, profile in
                 guard profile.hasModel, !profile.model.isEmpty else { return }
                 models[profile.inboxIdString.lowercased()] = profile.model

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
@@ -20,6 +20,56 @@ import XMTPiOS
 
 // MARK: - XMTPiOS.Group + CustomMetadata
 
+
+/// The mutation `XMTPGroup.updateAgentModel` performs, as a plain function so
+/// it can be exercised without a group.
+///
+/// Authors the agent's profile when the room carries none, because profiles
+/// travel as ProfileUpdate messages and appData holds one only for a member who
+/// has published an avatar — so there is usually nothing to hang a model on.
+func applyAgentModel(
+    _ model: String?,
+    to metadata: inout ConversationCustomMetadata,
+    forAgent inboxId: String,
+    name: String? = nil
+) {
+    let key = inboxId.lowercased()
+    if let index = metadata.profiles.firstIndex(where: {
+        $0.inboxIdString.lowercased() == key
+    }) {
+        if let model {
+            metadata.profiles[index].model = model
+        } else {
+            metadata.profiles[index].clearModel()
+        }
+        return
+    }
+    // Nothing to author for a clear: with no profile there is no model recorded
+    // to take back.
+    guard let model, let inboxIdData = Data(hexString: key) else { return }
+    var profile = ConversationProfile()
+    profile.inboxID = inboxIdData
+    if let name, !name.isEmpty { profile.name = name }
+    profile.model = model
+    metadata.profiles.append(profile)
+}
+
+/// Whether `metadata` already says what `applyAgentModel` was asked to write.
+func agentModelMatches(
+    _ model: String?,
+    in metadata: ConversationCustomMetadata,
+    forAgent inboxId: String
+) -> Bool {
+    let key = inboxId.lowercased()
+    let profile = metadata.profiles.first { $0.inboxIdString.lowercased() == key }
+    if let model {
+        return profile?.model == model
+    }
+    // A cleared model and a profile that was never authored both read as the
+    // agent carrying no model, which is the state asked for.
+    return profile?.hasModel != true
+}
+
 extension XMTPiOS.Group {
     private static let appDataByteLimit: Int = 8 * 1024
 
@@ -113,9 +163,12 @@ extension XMTPiOS.Group {
     /// carries one entry each, and an agent nobody has switched carries none —
     /// it runs whatever its own template shipped, which only it can name.
     ///
-    /// Read-only. The Assistant Worker validates a choice against that agent's
-    /// own catalogue and publishes it; a client writing here would broadcast a
-    /// model the agent may refuse.
+    /// Written by the member who picks it, the way the participation mode is,
+    /// so the commit carries that member's name into the transcript. The
+    /// Assistant Worker still owns the value: it validates a choice against the
+    /// agent's own catalogue and republishes here whenever the row moves on its
+    /// side — a refused model, one dropped from the catalogue, or one chosen
+    /// before the agent had a conversation to publish into.
     /// Nil means the appData said nothing about models, which is not the same as
     /// saying there are none. `currentCustomMetadata` turns an unreadable blob
     /// into empty metadata rather than throwing, so an empty profile list is
@@ -130,6 +183,33 @@ extension XMTPiOS.Group {
                 guard profile.hasModel, !profile.model.isEmpty else { return }
                 models[profile.inboxIdString.lowercased()] = profile.model
             }
+        }
+    }
+
+    /// Sets the model one agent runs on, or clears it when nil, leaving every
+    /// other agent's entry alone.
+    ///
+    /// Optimistic, and deliberately so. The member's pick is written here first
+    /// and confirmed with the control plane after, which is what puts that
+    /// member's name on the transcript row rather than the agent's — the
+    /// Assistant Worker signs its own commits. If the runtime refuses the
+    /// model, the Worker rolls its row back and republishes, so the room
+    /// converges on what the agent actually runs.
+    ///
+    /// Authors a profile for the agent when the room carries none: profiles
+    /// travel as ProfileUpdate messages and appData holds one only for a member
+    /// who has published an avatar, so there is often nothing to hang a model
+    /// on. `name` is carried in when known so the entry cannot present the
+    /// agent as nameless to a client reading appData.
+    public func updateAgentModel(
+        _ model: String?,
+        forAgent inboxId: String,
+        name: String? = nil
+    ) async throws {
+        try await atomicUpdateMetadata(operation: "updateAgentModel") { metadata in
+            applyAgentModel(model, to: &metadata, forAgent: inboxId, name: name)
+        } verify: { metadata in
+            agentModelMatches(model, in: metadata, forAgent: inboxId)
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
@@ -104,6 +104,28 @@ extension XMTPiOS.Group {
         }
     }
 
+    /// The model each agent in the conversation runs on, keyed by lowercase hex
+    /// inbox id, for the agents that carry one.
+    ///
+    /// Read from synced group state, like the participation mode, so a member
+    /// sees what every other member's agent was switched to without asking a
+    /// server. Unlike the mode, this is per agent: a room holding several
+    /// carries one entry each, and an agent nobody has switched carries none —
+    /// it runs whatever its own template shipped, which only it can name.
+    ///
+    /// Read-only. The Assistant Worker validates a choice against that agent's
+    /// own catalogue and publishes it; a client writing here would broadcast a
+    /// model the agent may refuse.
+    public var agentModels: [String: String] {
+        get throws {
+            let metadata = try currentCustomMetadata
+            return metadata.profiles.reduce(into: [:]) { models, profile in
+                guard profile.hasModel, !profile.model.isEmpty else { return }
+                models[profile.inboxIdString.lowercased()] = profile.model
+            }
+        }
+    }
+
     /// Whether this conversation carries the agent-DM marker. The agent's
     /// identity comes from the membership itself (member kind plus
     /// attestation), not from the marker; callers gating UI should also

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
@@ -20,7 +20,6 @@ import XMTPiOS
 
 // MARK: - XMTPiOS.Group + CustomMetadata
 
-
 /// The mutation `XMTPGroup.updateAgentModel` performs, as a plain function so
 /// it can be exercised without a group.
 ///

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockConversationMetadataWriter.swift
@@ -14,7 +14,12 @@ public final class MockConversationMetadataWriter: ConversationMetadataWriterPro
     public var updatedImages: [(image: ImageType, conversation: Conversation)] = []
     public var updatedExpiresAt: [(expiresAt: Date, conversationId: String)] = []
     public var updatedParticipationModes: [(mode: ConversationParticipationMode, conversationId: String)] = []
-    public var updatedAgentModels: [(model: String?, agentInboxId: String, conversationId: String)] = []
+    public struct RecordedAgentModel: Sendable {
+        public let model: String?
+        public let agentInboxId: String
+        public let conversationId: String
+    }
+    public var updatedAgentModels: [RecordedAgentModel] = []
     public var updatedSpaceURLs: [(urlString: String?, conversationId: String)] = []
     public var updatedIncludeInfoInPublicPreview: [(enabled: Bool, conversationId: String)] = []
     public var lockedConversations: [String] = []
@@ -79,7 +84,11 @@ public final class MockConversationMetadataWriter: ConversationMetadataWriterPro
         in conversationId: String
     ) async throws {
         updatedAgentModels.append(
-            (model: model, agentInboxId: agentInboxId, conversationId: conversationId)
+            RecordedAgentModel(
+                model: model,
+                agentInboxId: agentInboxId,
+                conversationId: conversationId
+            )
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockConversationMetadataWriter.swift
@@ -14,6 +14,7 @@ public final class MockConversationMetadataWriter: ConversationMetadataWriterPro
     public var updatedImages: [(image: ImageType, conversation: Conversation)] = []
     public var updatedExpiresAt: [(expiresAt: Date, conversationId: String)] = []
     public var updatedParticipationModes: [(mode: ConversationParticipationMode, conversationId: String)] = []
+    public var updatedAgentModels: [(model: String?, agentInboxId: String, conversationId: String)] = []
     public var updatedSpaceURLs: [(urlString: String?, conversationId: String)] = []
     public var updatedIncludeInfoInPublicPreview: [(enabled: Bool, conversationId: String)] = []
     public var lockedConversations: [String] = []
@@ -70,6 +71,16 @@ public final class MockConversationMetadataWriter: ConversationMetadataWriterPro
 
     public func updateParticipationMode(_ mode: ConversationParticipationMode, for conversationId: String) async throws {
         updatedParticipationModes.append((mode: mode, conversationId: conversationId))
+    }
+
+    public func updateAgentModel(
+        _ model: String?,
+        forAgent agentInboxId: String,
+        in conversationId: String
+    ) async throws {
+        updatedAgentModels.append(
+            (model: model, agentInboxId: agentInboxId, conversationId: conversationId)
+        )
     }
 
     public func updateSpaceURL(_ urlString: String?, for conversationId: String) async throws {

--- a/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
@@ -419,6 +419,13 @@ private func summaryFromFirstMetadataChange(
             return "\(creatorDisplayName) paused agents, so they'll never see the following messages"
         }
         return "\(creatorDisplayName) set agents to \(mode.transcriptTitle)"
+    case .agentModel:
+        guard let newValue = metadataChange.newValue else { return nil }
+        // The model id, not a friendly name: the catalogue that names it lives
+        // inside the agent's container, and a transcript row has to render from
+        // the commit alone — including for a member whose device never read
+        // that catalogue.
+        return "\(creatorDisplayName) switched an agent to \(newValue)"
     case .metadata, .unknown:
         return nil
     }

--- a/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
@@ -360,6 +360,33 @@ public extension ConversationUpdate {
     }
 }
 
+/// Renders a model id the way a member should read it: `openai/gpt-5.6-luna`
+/// becomes `GPT 5.6 Luna`.
+///
+/// The provider is dropped because it names who hosts the model, not which
+/// model it is, and every row in the picker already belongs to one catalogue.
+/// The id is all a transcript row has to work from — the catalogue that carries
+/// friendly names lives inside the agent's container, and a member whose device
+/// never read it still has to see something legible.
+func displayNameForModelId(_ modelId: String) -> String {
+    // A leading `~` marks an auxiliary entry in the agent's own catalogue; it
+    // is bookkeeping, not part of the name.
+    let withoutMarker = modelId.hasPrefix("~") ? String(modelId.dropFirst()) : modelId
+    let name = withoutMarker.split(separator: "/").last.map(String.init) ?? withoutMarker
+    let words = name.split(separator: "-").map { word -> String in
+        let lowered = word.lowercased()
+        // Initialisms a title-cased word would mangle into "Gpt" and "Glm".
+        if ["gpt", "glm", "ai", "llm"].contains(lowered) {
+            return lowered.uppercased()
+        }
+        // A version fragment stays as it is: "4.6" has no case to fix.
+        guard let first = word.first, first.isLetter else { return String(word) }
+        return first.uppercased() + word.dropFirst()
+    }
+    // An id with nothing left to render is better shown raw than blank.
+    return words.isEmpty ? modelId : words.joined(separator: " ")
+}
+
 /// Resolves a member's rendered display name with the precedence:
 /// contact-list override, then per-conversation profile name, then
 /// "Agent" for known agents or "Somebody" for unnamed humans.
@@ -420,16 +447,19 @@ private func summaryFromFirstMetadataChange(
         }
         return "\(creatorDisplayName) set agents to \(mode.transcriptTitle)"
     case .agentModel:
-        // The model id, not a friendly name: the catalogue that names it lives
-        // inside the agent's container, and a transcript row has to render from
-        // the commit alone — including for a member whose device never read
-        // that catalogue.
+        // The picking member writes this into appData themselves, so the name
+        // in front of the row is theirs. It says "the agent" rather than naming
+        // one because the commit carries the model alone — which agent it
+        // belongs to lives in the profile the value hangs off, not in the
+        // change. A row the Assistant Worker published (a refused model rolled
+        // back, one dropped from the catalogue) reads as the agent's own name
+        // instead, which is honest: that one really was its doing.
         guard let newValue = metadataChange.newValue else {
             // No new model means the agent went back to its own default, which
             // this side cannot name — so the row says what happened instead.
-            return "\(creatorDisplayName) switched an agent back to its default model"
+            return "\(creatorDisplayName) switched the agent back to its default model"
         }
-        return "\(creatorDisplayName) switched an agent to \(newValue)"
+        return "\(creatorDisplayName) switched the agent to \(displayNameForModelId(newValue))"
     case .metadata, .unknown:
         return nil
     }

--- a/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
@@ -420,11 +420,15 @@ private func summaryFromFirstMetadataChange(
         }
         return "\(creatorDisplayName) set agents to \(mode.transcriptTitle)"
     case .agentModel:
-        guard let newValue = metadataChange.newValue else { return nil }
         // The model id, not a friendly name: the catalogue that names it lives
         // inside the agent's container, and a transcript row has to render from
         // the commit alone — including for a member whose device never read
         // that catalogue.
+        guard let newValue = metadataChange.newValue else {
+            // No new model means the agent went back to its own default, which
+            // this side cannot name — so the row says what happened instead.
+            return "\(creatorDisplayName) switched an agent back to its default model"
+        }
         return "\(creatorDisplayName) switched an agent to \(newValue)"
     case .metadata, .unknown:
         return nil

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversationMember.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversationMember.swift
@@ -109,7 +109,11 @@ extension DBConversationMember {
             role: role,
             consent: consent,
             createdAt: createdAt,
-            invitedByInboxId: invitedByInboxId
+            invitedByInboxId: invitedByInboxId,
+            // Carried over: a role change says nothing about the model the
+            // member is on, and dropping it here would blank the picker until
+            // the next full sync put it back.
+            agentModel: agentModel
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversationMember.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversationMember.swift
@@ -28,9 +28,9 @@ struct DBConversationMember: Codable, FetchableRecord, PersistableRecord, Hashab
     /// for an agent nobody has switched — which is not a model the client can
     /// name, since an unswitched agent runs whatever its own template shipped.
     ///
-    /// Read-only here: the Assistant Worker validates a choice against that
-    /// agent's own catalogue and publishes it, so this column mirrors a value
-    /// rather than authoring one.
+    /// Mirrored, never authored here: a pick is written into the group's
+    /// appData and this column follows the sync, so the value a device shows is
+    /// the one the room agreed on.
     var agentModel: String?
 
     static let memberForeignKey: ForeignKey = ForeignKey([Columns.inboxId], to: [DBMember.Columns.inboxId])

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversationMember.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversationMember.swift
@@ -13,6 +13,7 @@ struct DBConversationMember: Codable, FetchableRecord, PersistableRecord, Hashab
         static let consent: Column = Column(CodingKeys.consent)
         static let createdAt: Column = Column(CodingKeys.createdAt)
         static let invitedByInboxId: Column = Column(CodingKeys.invitedByInboxId)
+        static let agentModel: Column = Column(CodingKeys.agentModel)
     }
 
     let conversationId: String
@@ -21,6 +22,16 @@ struct DBConversationMember: Codable, FetchableRecord, PersistableRecord, Hashab
     let consent: Consent
     let createdAt: Date
     var invitedByInboxId: String?
+
+    /// The model this member runs on, when the member is an agent, mirrored
+    /// from its profile in the group's appData. Nil for a human member, and nil
+    /// for an agent nobody has switched — which is not a model the client can
+    /// name, since an unswitched agent runs whatever its own template shipped.
+    ///
+    /// Read-only here: the Assistant Worker validates a choice against that
+    /// agent's own catalogue and publishes it, so this column mirrors a value
+    /// rather than authoring one.
+    var agentModel: String?
 
     static let memberForeignKey: ForeignKey = ForeignKey([Columns.inboxId], to: [DBMember.Columns.inboxId])
     static let conversationForeignKey: ForeignKey = ForeignKey([Columns.conversationId], to: [DBConversation.Columns.id])

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift
@@ -12,6 +12,12 @@ public struct ConversationUpdate: Hashable, Codable, Sendable {
                  // carries every custom field, and only a mode change in it
                  // earns a transcript row.
                  participationMode = "participation_mode",
+                 // Also synthesized while decoding an `app_data` change: the
+                 // model lives on an agent's profile inside that same blob.
+                 // Carries the model id, not a member-facing name — the
+                 // catalogue that names it lives in the agent's container, and
+                 // the transcript must render from the commit alone.
+                 agentModel = "agent_model",
                  unknown
 
             var showsInMessagesList: Bool {

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -223,6 +223,25 @@ extension SharedDatabaseMigrator {
         migrator.registerMigration("addConversationParticipationMode", migrate: Self.addConversationParticipationMode)
         migrator.registerMigration("clearCutListenParticipationMode", migrate: Self.clearCutListenParticipationMode)
         migrator.registerMigration("addConversationSpaceURLString", migrate: Self.addConversationSpaceURLString)
+        migrator.registerMigration("addConversationMemberAgentModel", migrate: Self.addConversationMemberAgentModel)
+    }
+
+    /// The model one agent runs on, mirrored from that agent's profile in the
+    /// group's appData (the Assistant Worker publishes it; clients only read).
+    ///
+    /// It sits on the membership row rather than on `conversation`, which is
+    /// where the participation mode sits, because the two are scoped
+    /// differently: a mode governs the whole room, while a model belongs to one
+    /// agent and a room can hold several. `conversation_members` is already
+    /// keyed by exactly that pair.
+    ///
+    /// Nullable with no default. Null is an agent nobody has switched, which is
+    /// not the same as an agent on a known model: it runs whatever its own
+    /// template shipped, and only the agent can say what that is.
+    static func addConversationMemberAgentModel(_ db: Database) throws {
+        try db.alter(table: "conversation_members") { t in
+            t.add(column: "agentModel", .text)
+        }
     }
 
     /// The deployed Space web URL for the conversation, mirrored from the

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
@@ -20,6 +20,11 @@ public protocol ConversationMetadataWriterProtocol: Sendable {
     func updateImage(_ image: ImageType, for conversation: Conversation) async throws
     func updateExpiresAt(_ expiresAt: Date, for conversationId: String) async throws
     func updateParticipationMode(_ mode: ConversationParticipationMode, for conversationId: String) async throws
+    func updateAgentModel(
+        _ model: String?,
+        forAgent agentInboxId: String,
+        in conversationId: String
+    ) async throws
     func updateSpaceURL(_ urlString: String?, for conversationId: String) async throws
     func updateIncludeInfoInPublicPreview(_ enabled: Bool, for conversationId: String) async throws
     func lockConversation(for conversationId: String) async throws
@@ -161,6 +166,49 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol, @unc
 
         Log.info("Updated conversation participation mode for \(conversationId): \(mode.rawValue)")
         QAEvent.emit(.conversation, "participation_mode_updated", ["id": conversationId, "mode": mode.rawValue])
+    }
+
+    /// Publishes the model a member just picked for one agent into the group's
+    /// appData, so every other member's client can name it.
+    ///
+    /// Written from the picking member's device, like the participation mode,
+    /// which is what puts their name on the transcript row: the Assistant
+    /// Worker signs its own commits, so a row it wrote reads as the agent
+    /// switching itself. The Worker remains the value's authority and
+    /// republishes here whenever its row moves — including rolling back a model
+    /// the runtime refused.
+    ///
+    /// The agent's name is carried in from the local member row when we have
+    /// it, because writing the model may have to author the agent's appData
+    /// profile from nothing.
+    func updateAgentModel(
+        _ model: String?,
+        forAgent agentInboxId: String,
+        in conversationId: String
+    ) async throws {
+        let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+
+        guard let conversation = try await inboxReady.client.conversation(with: conversationId),
+              case .group(let group) = conversation else {
+            throw ConversationMetadataError.conversationNotFound(conversationId: conversationId)
+        }
+
+        let agentName: String? = try? await databaseWriter.read { db in
+            try DBMemberProfile
+                .filter(DBMemberProfile.Columns.conversationId == conversationId)
+                .filter(DBMemberProfile.Columns.inboxId == agentInboxId)
+                .fetchOne(db)?
+                .name
+        }
+
+        try await group.updateAgentModel(model, forAgent: agentInboxId, name: agentName)
+
+        Log.info("Updated agent model for \(agentInboxId) in \(conversationId): \(model ?? "default")")
+        QAEvent.emit(
+            .conversation,
+            "agent_model_updated",
+            ["id": conversationId, "agent": agentInboxId, "model": model ?? "default"]
+        )
     }
 
     /// Debug override for the Space web URL. The Assistant Worker is the

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -287,7 +287,14 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         try await denyConsentIfInviteWasLocallyDeleted(for: conversation)
         let metadata = try await extractConversationMetadata(from: conversation)
         let members = try await conversation.members
-        let dbMembers = members.map { $0.dbRepresentation(conversationId: conversation.id) }
+        // The roster knows the members; the appData knows which of them is an
+        // agent that has been switched, and to what. Joined here, while both
+        // are in hand, so the row that gets saved already carries the model.
+        let dbMembers = members.map { member -> DBConversationMember in
+            var row = member.dbRepresentation(conversationId: conversation.id)
+            row.agentModel = metadata.agentModels[member.inboxId.lowercased()]
+            return row
+        }
         let memberProfiles = try conversation.memberProfiles
         let dbConversation = try await createDBConversation(
             from: conversation,
@@ -813,6 +820,11 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         /// The deployed Space web URL carried in the group's appData; the
         /// Assistant Worker is the sole authority. Nil until one is published.
         let spaceURLString: String?
+        /// The model each agent in this conversation runs on, keyed by
+        /// lowercase hex inbox id, for the agents carrying one. The Assistant
+        /// Worker publishes these; clients only read. Empty when no agent here
+        /// has been switched.
+        let agentModels: [String: String]
         let memberCount: Int
     }
 
@@ -864,6 +876,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             originConversationId: originConversationId,
             participationMode: try? conversation.participationMode,
             spaceURLString: (try? conversation.spaceURL).flatMap { $0 },
+            agentModels: (try? conversation.agentModels) ?? [:],
             memberCount: memberCount
         )
     }
@@ -1296,7 +1309,16 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
                 role: member.role,
                 consent: member.consent,
                 createdAt: existing?.createdAt ?? member.createdAt,
-                invitedByInboxId: existing?.invitedByInboxId ?? member.invitedByInboxId
+                invitedByInboxId: existing?.invitedByInboxId ?? member.invitedByInboxId,
+                // Deliberately NOT coalesced with the stored row, unlike the
+                // two above. Those are local facts the roster cannot restate,
+                // so a rebuild has to carry them; this one is mirrored from
+                // appData and the incoming value is the whole answer — nil
+                // means appData names no model for this member. Falling back to
+                // the stored value would make clearing a model impossible: the
+                // agent would keep reporting the one it was switched away from,
+                // with nothing left to correct it.
+                agentModel: member.agentModel
             )
             try memberToSave.save(db)
             let memberProfile = DBMemberProfile(

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -259,6 +259,10 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         let dbConversation: DBConversation
         let dbMembers: [DBConversationMember]
         let memberProfiles: [DBMemberProfile]
+        /// Whether the appData this was prepared from actually spoke about agent
+        /// models. False means stored values must be preserved rather than
+        /// overwritten with the nils in `dbMembers`.
+        let agentModelsAreAuthoritative: Bool
         /// The DM's parent group id, when this conversation is an agent DM that
         /// recorded one; persisted to `agent_dm_origin` in `persist`.
         var originConversationId: String?
@@ -290,9 +294,11 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         // The roster knows the members; the appData knows which of them is an
         // agent that has been switched, and to what. Joined here, while both
         // are in hand, so the row that gets saved already carries the model.
+        // A nil map means the appData told us nothing, and the rows carry nil so
+        // `saveMembers` keeps whatever is already stored.
         let dbMembers = members.map { member -> DBConversationMember in
             var row = member.dbRepresentation(conversationId: conversation.id)
-            row.agentModel = metadata.agentModels[member.inboxId.lowercased()]
+            row.agentModel = metadata.agentModels?[member.inboxId.lowercased()]
             return row
         }
         let memberProfiles = try conversation.memberProfiles
@@ -307,6 +313,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             dbConversation: dbConversation,
             dbMembers: dbMembers,
             memberProfiles: memberProfiles,
+            agentModelsAreAuthoritative: metadata.agentModels != nil,
             originConversationId: metadata.originConversationId
         )
     }
@@ -429,7 +436,11 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             in: db
         )
 
-        try saveMembers(activeMembers, in: db)
+        try saveMembers(
+            activeMembers,
+            agentModelsAreAuthoritative: prepared.agentModelsAreAuthoritative,
+            in: db
+        )
 
         // Fill gaps from the group's app-data profiles. The canonical write is
         // what rendering reads; the legacy `DBMemberProfile` write is kept
@@ -822,9 +833,13 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         let spaceURLString: String?
         /// The model each agent in this conversation runs on, keyed by
         /// lowercase hex inbox id, for the agents carrying one. The Assistant
-        /// Worker publishes these; clients only read. Empty when no agent here
-        /// has been switched.
-        let agentModels: [String: String]
+        /// Worker publishes these; clients only read.
+        ///
+        /// Nil when the appData carried no profiles at all, which is what an
+        /// unreadable blob also looks like — it says nothing about models, so
+        /// stored values are kept rather than cleared. Empty (non-nil) is a real
+        /// answer: profiles are present and none names a model.
+        let agentModels: [String: String]?
         let memberCount: Int
     }
 
@@ -876,7 +891,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             originConversationId: originConversationId,
             participationMode: try? conversation.participationMode,
             spaceURLString: (try? conversation.spaceURL).flatMap { $0 },
-            agentModels: (try? conversation.agentModels) ?? [:],
+            agentModels: (try? conversation.agentModels).flatMap { $0 },
             memberCount: memberCount
         )
     }
@@ -1296,7 +1311,15 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             .fetchOne(db)
     }
 
-    private func saveMembers(_ dbMembers: [DBConversationMember], in db: Database) throws {
+    /// `agentModelsAreAuthoritative` says whether the appData this batch came
+    /// from actually spoke about models. When it did not, stored values are kept
+    /// — clearing them on an unreadable read would blank every switched agent in
+    /// the conversation at once.
+    private func saveMembers(
+        _ dbMembers: [DBConversationMember],
+        agentModelsAreAuthoritative: Bool,
+        in db: Database
+    ) throws {
         for member in dbMembers {
             try DBMember(inboxId: member.inboxId).save(db)
             let existing = try DBConversationMember
@@ -1310,15 +1333,17 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
                 consent: member.consent,
                 createdAt: existing?.createdAt ?? member.createdAt,
                 invitedByInboxId: existing?.invitedByInboxId ?? member.invitedByInboxId,
-                // Deliberately NOT coalesced with the stored row, unlike the
-                // two above. Those are local facts the roster cannot restate,
-                // so a rebuild has to carry them; this one is mirrored from
-                // appData and the incoming value is the whole answer — nil
-                // means appData names no model for this member. Falling back to
-                // the stored value would make clearing a model impossible: the
-                // agent would keep reporting the one it was switched away from,
-                // with nothing left to correct it.
-                agentModel: member.agentModel
+                // Coalesced only when the appData did not speak. When it did,
+                // the incoming value is the whole answer and nil means "no model
+                // for this member" — falling back there would make clearing a
+                // model impossible, leaving the agent reporting the one it was
+                // switched away from with nothing left to correct it. When it
+                // did not speak, the opposite risk applies and the stored value
+                // is the only thing standing between a bad read and every
+                // switched agent in the room going blank.
+                agentModel: agentModelsAreAuthoritative
+                    ? member.agentModel
+                    : (member.agentModel ?? existing?.agentModel)
             )
             try memberToSave.save(db)
             let memberProfile = DBMemberProfile(

--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
@@ -434,16 +434,22 @@ extension XMTPiOS.DecodedMessage {
         // Only the first differing agent earns a row — a commit that moved two
         // agents at once is not something the transcript can say in one line,
         // and naming one is better than naming neither.
+        //
+        // Walks the union of both sides, not just the new one: switching an
+        // agent back to its own default REMOVES its key, and a new-side-only
+        // scan never visits a removed key, so that change would fall through to
+        // the silent metadata row and leave no trace in the transcript.
         let oldModels = oldCustomValue.map(agentModels) ?? [:]
         let newModels = newCustomValue.map(agentModels) ?? [:]
         if !isCreatorSeedCommit,
-           let changed = newModels
-               .filter({ oldModels[$0.key] != $0.value })
-               .min(by: { $0.key < $1.key }) {
+           let changedKey = Set(oldModels.keys)
+               .union(newModels.keys)
+               .filter({ oldModels[$0] != newModels[$0] })
+               .min() {
             return .init(
                 field: ConversationUpdate.MetadataChange.Field.agentModel.rawValue,
-                oldValue: oldModels[changed.key],
-                newValue: changed.value
+                oldValue: oldModels[changedKey],
+                newValue: newModels[changedKey]
             )
         }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
@@ -428,6 +428,25 @@ extension XMTPiOS.DecodedMessage {
             )
         }
 
+        // A model change reads out of the same blob, off the agents' profiles.
+        // Suppressed on the creator's seed commit for the same reason the mode
+        // is: that commit is the room's starting state, not a member's choice.
+        // Only the first differing agent earns a row — a commit that moved two
+        // agents at once is not something the transcript can say in one line,
+        // and naming one is better than naming neither.
+        let oldModels = oldCustomValue.map(agentModels) ?? [:]
+        let newModels = newCustomValue.map(agentModels) ?? [:]
+        if !isCreatorSeedCommit,
+           let changed = newModels
+               .filter({ oldModels[$0.key] != $0.value })
+               .min(by: { $0.key < $1.key }) {
+            return .init(
+                field: ConversationUpdate.MetadataChange.Field.agentModel.rawValue,
+                oldValue: oldModels[changed.key],
+                newValue: changed.value
+            )
+        }
+
         let oldExpiresAt: Date? = oldCustomValue.flatMap(expiresAtDate)
         let newExpiresAt: Date? = newCustomValue.flatMap(expiresAtDate)
         if oldExpiresAt != newExpiresAt {
@@ -444,6 +463,17 @@ extension XMTPiOS.DecodedMessage {
             oldValue: nil,
             newValue: nil
         )
+    }
+
+    /// The model each agent carries in one appData blob, keyed by lowercase hex
+    /// inbox id. Agents with no model are absent rather than mapped to "": an
+    /// unswitched agent runs its own template default, which the blob cannot
+    /// name.
+    private static func agentModels(_ metadata: ConversationCustomMetadata) -> [String: String] {
+        metadata.profiles.reduce(into: [:]) { models, profile in
+            guard profile.hasModel, !profile.model.isEmpty else { return }
+            models[profile.inboxIdString.lowercased()] = profile.model
+        }
     }
 
     private static func expiresAtDate(_ metadata: ConversationCustomMetadata) -> Date? {

--- a/ConvosCore/Tests/ConvosCoreIntegrationTests/DeletedPendingInviteTests.swift
+++ b/ConvosCore/Tests/ConvosCoreIntegrationTests/DeletedPendingInviteTests.swift
@@ -33,7 +33,8 @@ struct DeletedPendingInviteTests {
         let prepared = ConversationWriter.PreparedConversation(
             dbConversation: incoming,
             dbMembers: [],
-            memberProfiles: []
+            memberProfiles: [],
+            agentModelsAreAuthoritative: false
         )
         let saveResult = try await dbManager.dbWriter.write { db in
             try writer.persist(prepared, in: db)
@@ -70,7 +71,8 @@ struct DeletedPendingInviteTests {
         let prepared = ConversationWriter.PreparedConversation(
             dbConversation: incoming,
             dbMembers: [],
-            memberProfiles: []
+            memberProfiles: [],
+            agentModelsAreAuthoritative: false
         )
         let saveResult = try await dbManager.dbWriter.write { db in
             try writer.persist(prepared, in: db)

--- a/ConvosCore/Tests/ConvosCoreTests/AgentModelSyncTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentModelSyncTests.swift
@@ -1,0 +1,197 @@
+import ConvosAppData
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+import XMTPiOS
+
+/// Covers the agent model's trip through the client: the appData blob it
+/// travels in, the column it lands in, and the transcript row a change leaves
+/// behind (CON-958).
+///
+/// The model deliberately does not follow the participation mode everywhere it
+/// goes, and the differences are what most of these pin: it is scoped to one
+/// agent rather than to the room, it is read-only on the client, and an agent
+/// carrying no model is not an agent on a known one.
+@Suite("Agent model sync", .serialized)
+struct AgentModelSyncTests {
+    private static let agentInboxId = "aa".repeat(32)
+    private static let otherAgentInboxId = "bb".repeat(32)
+
+    // MARK: - Migration
+
+    @Test("migration adds a nullable agentModel column and leaves existing rows unset")
+    func migrationAddsNullableColumn() throws {
+        let dbQueue = try DatabaseQueue()
+        try dbQueue.write { db in
+            try db.create(table: "conversation_members") { t in
+                t.column("conversationId", .text).notNull()
+                t.column("inboxId", .text).notNull()
+                t.primaryKey(["conversationId", "inboxId"])
+            }
+            try db.execute(
+                sql: "INSERT INTO conversation_members (conversationId, inboxId) VALUES (?, ?)",
+                arguments: ["convo-1", Self.agentInboxId]
+            )
+
+            try SharedDatabaseMigrator.addConversationMemberAgentModel(db)
+        }
+
+        let stored: String? = try dbQueue.read { db in
+            try String.fetchOne(
+                db,
+                sql: "SELECT agentModel FROM conversation_members WHERE conversationId = ?",
+                arguments: ["convo-1"]
+            )
+        }
+        #expect(stored == nil)
+    }
+
+    // MARK: - appData wire format
+
+    @Test("a model survives the appData blob a group metadata commit carries")
+    func modelSurvivesAppDataRoundTrip() throws {
+        var profile = ConversationProfile()
+        profile.inboxID = Data(repeating: 0xAA, count: 32)
+        profile.model = "anthropic/claude-sonnet-5"
+        var metadata = ConversationCustomMetadata()
+        metadata.tag = "tag"
+        metadata.profiles = [profile]
+
+        let decoded = try ConversationCustomMetadata.fromCompactString(metadata.toCompactString())
+
+        #expect(decoded.profiles.first?.model == "anthropic/claude-sonnet-5")
+        #expect(decoded.tag == "tag")
+    }
+
+    /// The whole reason this hangs off the profile rather than the conversation:
+    /// a room can hold several agents and they do not share a model.
+    @Test("two agents in one conversation carry independent models")
+    func twoAgentsCarryIndependentModels() throws {
+        var first = ConversationProfile()
+        first.inboxID = Data(repeating: 0xAA, count: 32)
+        first.model = "anthropic/claude-sonnet-5"
+        var second = ConversationProfile()
+        second.inboxID = Data(repeating: 0xBB, count: 32)
+        second.model = "anthropic/claude-haiku-4-5"
+        var metadata = ConversationCustomMetadata()
+        metadata.profiles = [first, second]
+
+        let decoded = try ConversationCustomMetadata.fromCompactString(metadata.toCompactString())
+
+        #expect(decoded.profiles.count == 2)
+        #expect(decoded.profiles[0].model == "anthropic/claude-sonnet-5")
+        #expect(decoded.profiles[1].model == "anthropic/claude-haiku-4-5")
+    }
+
+    /// An agent nobody has switched runs whatever its own template shipped, and
+    /// the blob cannot name that. Reading absent as "" would let the client
+    /// claim it knows something it does not.
+    @Test("an unset model reads as no model, not as an empty one")
+    func unsetModelReadsAsAbsent() throws {
+        var profile = ConversationProfile()
+        profile.inboxID = Data(repeating: 0xAA, count: 32)
+        var metadata = ConversationCustomMetadata()
+        metadata.profiles = [profile]
+
+        let decoded = try ConversationCustomMetadata.fromCompactString(metadata.toCompactString())
+
+        #expect(decoded.profiles.first?.hasModel == false)
+    }
+
+    // MARK: - Transcript rendering
+
+    @Test("a model change decodes into an agent-model update row")
+    func modelChangeProducesAgentModelChange() throws {
+        var profile = ConversationProfile()
+        profile.inboxID = Data(repeating: 0xAA, count: 32)
+        var before = ConversationCustomMetadata()
+        before.tag = "tag"
+        before.profiles = [profile]
+
+        var switched = profile
+        switched.model = "anthropic/claude-sonnet-5"
+        var after = before
+        after.profiles = [switched]
+
+        let change = XMTPiOS.DecodedMessage.appDataMetadataChange(
+            oldValue: try before.toCompactString(),
+            newValue: try after.toCompactString()
+        )
+
+        #expect(change.field == ConversationUpdate.MetadataChange.Field.agentModel.rawValue)
+        #expect(change.newValue == "anthropic/claude-sonnet-5")
+        #expect(change.oldValue == nil)
+        #expect(ConversationUpdate.MetadataChange.Field.agentModel.showsInMessagesList)
+    }
+
+    @Test("switching from one model to another carries the model left behind")
+    func modelChangeCarriesPreviousModel() throws {
+        var profile = ConversationProfile()
+        profile.inboxID = Data(repeating: 0xAA, count: 32)
+        profile.model = "anthropic/claude-haiku-4-5"
+        var before = ConversationCustomMetadata()
+        before.tag = "tag"
+        before.profiles = [profile]
+
+        var switched = profile
+        switched.model = "anthropic/claude-sonnet-5"
+        var after = before
+        after.profiles = [switched]
+
+        let change = XMTPiOS.DecodedMessage.appDataMetadataChange(
+            oldValue: try before.toCompactString(),
+            newValue: try after.toCompactString()
+        )
+
+        #expect(change.oldValue == "anthropic/claude-haiku-4-5")
+        #expect(change.newValue == "anthropic/claude-sonnet-5")
+    }
+
+    /// Same rule the participation mode follows: the commit that first authors
+    /// the invite tag is the room's starting state, not a member's choice.
+    @Test("the creator seed (tag and model set together) leaves no agent-model row")
+    func creatorSeedStaysSilent() throws {
+        var profile = ConversationProfile()
+        profile.inboxID = Data(repeating: 0xAA, count: 32)
+        profile.model = "anthropic/claude-sonnet-5"
+        let before = ConversationCustomMetadata()
+        var after = ConversationCustomMetadata()
+        after.tag = "tag"
+        after.profiles = [profile]
+
+        let change = XMTPiOS.DecodedMessage.appDataMetadataChange(
+            oldValue: try before.toCompactString(),
+            newValue: try after.toCompactString()
+        )
+
+        #expect(change.field != ConversationUpdate.MetadataChange.Field.agentModel.rawValue)
+    }
+
+    /// A commit that changed something else entirely must not be read as a
+    /// model change just because the profiles are present in both blobs.
+    @Test("an unrelated change leaves no agent-model row")
+    func unrelatedChangeStaysSilent() throws {
+        var profile = ConversationProfile()
+        profile.inboxID = Data(repeating: 0xAA, count: 32)
+        profile.model = "anthropic/claude-sonnet-5"
+        var before = ConversationCustomMetadata()
+        before.tag = "tag"
+        before.profiles = [profile]
+        var after = before
+        after.emoji = "🎧"
+
+        let change = XMTPiOS.DecodedMessage.appDataMetadataChange(
+            oldValue: try before.toCompactString(),
+            newValue: try after.toCompactString()
+        )
+
+        #expect(change.field != ConversationUpdate.MetadataChange.Field.agentModel.rawValue)
+    }
+}
+
+private extension String {
+    func `repeat`(_ count: Int) -> String {
+        String(repeating: self, count: count)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/AgentModelSyncTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentModelSyncTests.swift
@@ -99,6 +99,79 @@ struct AgentModelSyncTests {
         #expect(decoded.profiles.first?.hasModel == false)
     }
 
+    // MARK: - Writing a pick into appData
+
+    /// The pick is written from the picking member's device, which is what puts
+    /// their name on the transcript row instead of the agent's.
+    @Test("writing a model leaves every other agent's entry alone")
+    func writingModelLeavesOtherAgentsAlone() throws {
+        var mine = ConversationProfile()
+        mine.inboxID = Data(repeating: 0xAA, count: 32)
+        mine.model = "anthropic/claude-haiku-4-5"
+        var other = ConversationProfile()
+        other.inboxID = Data(repeating: 0xBB, count: 32)
+        other.model = "openai/gpt-5.5"
+        var metadata = ConversationCustomMetadata()
+        metadata.tag = "tag"
+        metadata.profiles = [mine, other]
+
+        applyAgentModel("anthropic/claude-sonnet-5", to: &metadata, forAgent: Self.agentInboxId)
+
+        #expect(metadata.profiles[0].model == "anthropic/claude-sonnet-5")
+        #expect(metadata.profiles[1].model == "openai/gpt-5.5")
+    }
+
+    /// Profiles travel as ProfileUpdate messages and appData holds one only for
+    /// a member with an avatar, so there is usually nothing to hang a model on.
+    @Test("writing a model authors the agent's profile when there is none")
+    func writingModelAuthorsProfile() throws {
+        var metadata = ConversationCustomMetadata()
+        metadata.tag = "tag"
+
+        applyAgentModel(
+            "anthropic/claude-sonnet-5",
+            to: &metadata,
+            forAgent: Self.agentInboxId,
+            name: "picker-test"
+        )
+
+        #expect(metadata.profiles.count == 1)
+        #expect(metadata.profiles[0].model == "anthropic/claude-sonnet-5")
+        #expect(metadata.profiles[0].name == "picker-test")
+    }
+
+    /// Nothing to take back, so nothing is worth a commit.
+    @Test("clearing a model the room never carried authors nothing")
+    func clearingUnknownModelAuthorsNothing() throws {
+        var metadata = ConversationCustomMetadata()
+        metadata.tag = "tag"
+
+        applyAgentModel(nil, to: &metadata, forAgent: Self.agentInboxId)
+
+        #expect(metadata.profiles.isEmpty)
+    }
+
+    // MARK: - Model name rendering
+
+    /// The transcript has only the id to work from, and a raw
+    /// `openai/gpt-5.6-luna` is not something to show a member.
+    @Test("a model id renders as a name, without its provider")
+    func modelIdRendersAsName() {
+        #expect(displayNameForModelId("openai/gpt-5.6-luna") == "GPT 5.6 Luna")
+        #expect(displayNameForModelId("anthropic/claude-sonnet-5") == "Claude Sonnet 5")
+        #expect(displayNameForModelId("x-ai/grok-4.6") == "Grok 4.6")
+        #expect(displayNameForModelId("z-ai/glm-5.2") == "GLM 5.2")
+        #expect(displayNameForModelId("moonshotai/kimi-k3") == "Kimi K3")
+    }
+
+    /// The `~` prefix marks an auxiliary entry in the agent's catalogue. It is
+    /// bookkeeping, and a member reading the transcript should never see it.
+    @Test("an auxiliary marker and a bare id both render")
+    func markerAndBareIdRender() {
+        #expect(displayNameForModelId("~google/gemini-flash-latest") == "Gemini Flash Latest")
+        #expect(displayNameForModelId("grok-4.6") == "Grok 4.6")
+    }
+
     // MARK: - Transcript rendering
 
     @Test("a model change decodes into an agent-model update row")

--- a/ConvosCore/Tests/ConvosCoreTests/AgentModelSyncTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentModelSyncTests.swift
@@ -168,6 +168,33 @@ struct AgentModelSyncTests {
         #expect(change.field != ConversationUpdate.MetadataChange.Field.agentModel.rawValue)
     }
 
+    /// Switching an agent back to its own default removes the key rather than
+    /// setting it to something, and a scan of only the new side never visits a
+    /// removed key — so this change used to leave no transcript row at all.
+    @Test("clearing a model still produces an agent-model row")
+    func clearingModelProducesAgentModelChange() throws {
+        var profile = ConversationProfile()
+        profile.inboxID = Data(repeating: 0xAA, count: 32)
+        profile.model = "anthropic/claude-sonnet-5"
+        var before = ConversationCustomMetadata()
+        before.tag = "tag"
+        before.profiles = [profile]
+
+        var cleared = profile
+        cleared.clearModel()
+        var after = before
+        after.profiles = [cleared]
+
+        let change = XMTPiOS.DecodedMessage.appDataMetadataChange(
+            oldValue: try before.toCompactString(),
+            newValue: try after.toCompactString()
+        )
+
+        #expect(change.field == ConversationUpdate.MetadataChange.Field.agentModel.rawValue)
+        #expect(change.oldValue == "anthropic/claude-sonnet-5")
+        #expect(change.newValue == nil)
+    }
+
     /// A commit that changed something else entirely must not be read as a
     /// model change just because the profiles are present in both blobs.
     @Test("an unrelated change leaves no agent-model row")

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationExplosionWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationExplosionWriterTests.swift
@@ -345,6 +345,11 @@ private final class RecordingMetadataWriter: ConversationMetadataWriterProtocol,
     }
 
     func updateParticipationMode(_ mode: ConversationParticipationMode, for conversationId: String) async throws {}
+    func updateAgentModel(
+        _ model: String?,
+        forAgent agentInboxId: String,
+        in conversationId: String
+    ) async throws {}
     func updateSpaceURL(_ urlString: String?, for conversationId: String) async throws {}
     func updateIncludeInfoInPublicPreview(_ enabled: Bool, for conversationId: String) async throws {}
     func lockConversation(for conversationId: String) async throws {}

--- a/ConvosCore/Tests/ConvosCoreTests/MemberDepartureTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MemberDepartureTests.swift
@@ -365,7 +365,8 @@ struct MemberDepartureTests {
                     invitedByInboxId: nil
                 )
             },
-            memberProfiles: []
+            memberProfiles: [],
+            agentModelsAreAuthoritative: false
         )
         try dbManager.dbWriter.write { db in
             _ = try writer.persist(prepared, in: db)


### PR DESCRIPTION
The model picker writes to the control plane and reads back from it, so the chosen model never reaches anyone else: a switch made on one phone is invisible on every other device in the room. The participation level already solved this by riding the group's appData, and this follows it (CON-958).

## What carries it

`ConversationProfile.model` (field 6), hanging off the agent's own profile rather than off the conversation. That is the one place the two settings genuinely differ: a participation level governs the whole room, while a model belongs to one agent and a room can hold several, each on its own model.

## Read-only here, and that is the point

The picker's existing write is **untouched**. A model can be refused — an agent only runs what its own catalogue lists — so the Assistant Worker validates and applies a choice before publishing it. A client writing appData first would broadcast a model the agent may never run.

This is worth holding onto, because `AgentModelStore` and `AgentParticipationStore` otherwise read as twins and the asymmetry looks like an oversight. It isn't: participation writes appData from the client, this one never does. `apply(syncedModel:)` is the new half — what lets another member's switch land here — and it yields to a local write in flight for the same reason its participation twin does.

The value comes from synced group state; the **catalogue** stays a control-plane read, since what an agent can run lives in its container and has no business in appData.

## Storage

The column sits on `conversation_members`, already keyed by exactly the (conversation, agent) pair the value belongs to — which kept it out of the `ProfileMerge` precedence machinery, where it does not belong: this is not identity.

It is mirrored, not authored, and so unlike `createdAt` it is deliberately **not** carried forward across a re-sync. The incoming appData value is the whole answer; falling back to the stored one would make clearing a model impossible — the agent would keep reporting the one it was switched away from with nothing left to correct it.

## Transcript

A change leaves a row, synthesized off the metadata commit like the participation one and suppressed on the creator's seed commit for the same reason. It renders the model **id**, not a friendly name: the catalogue that names it lives in the agent's container, and the row has to render from the commit alone — including on a device that never read that catalogue.

## Companion

Server half: xmtplabs/convos-assistants#3666. The two are joined by a fixture: `agentModelDecodesFromHeraldBlob` decodes a blob produced verbatim by that writer, so the cross-repo field assignment is pinned from both sides rather than asserted twice in the same shape.

## Note

The picker remains behind `isAgentModelPickerEnabled`, default off. Opening it is a later step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJDsxfPEMkfpvQfBLLcAEk

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790363109&installation_model_id=20076&pr_number=1445&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1445&signature=873c4bee6ec813bb108b250ba63e9537a1c4596bbf3a32e5a99238dea685bd2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-agent `model` field synced via group appData and `ConversationProfile`
> - Adds an optional `model` field (tag 6) to `ConversationProfile` in [conversation_custom_metadata.proto](https://github.com/xmtplabs/convos-ios/pull/1445/files#diff-2b7c2d239d27b14c3b07326f429faf776a171bce63032e4b8e3f1f48cb7ef963) and a nullable `agentModel` column to `conversation_members` via migration `addConversationMemberAgentModel` in [SharedDatabaseMigrator.swift](https://github.com/xmtplabs/convos-ios/pull/1445/files#diff-1d28d03ee0fb38381b6052060082c7561fa8ccc71fda470214d763f53a4414df)
> - `ConversationWriter` now maps `metadata.agentModels` into member rows, tracking `agentModelsAreAuthoritative` so clearing works while protecting stored values when appData omits model data
> - [ConversationMetadataWriter.swift](https://github.com/xmtplabs/convos-ios/pull/1445/files#diff-ce17de6d3ad64e828d2531d31326211c4a7d54f39e9e4e299402b089d206eeaf) adds `updateAgentModel(_:forAgent:in:)` which calls `Group.updateAgentModel` to optimistically write/clear the model in appData, verified via `agentModelMatches`
> - [ContactDetailView.swift](https://github.com/xmtplabs/convos-ios/pull/1445/files#diff-fa54c9aca0b6a99cd254f52934d6ffb2f3d79b79ff6ee084feb9ebda7d8d03a4) plumbs a `ConversationAppDataAgentModelService` so the model picker writes to appData first, then mirrors to the control plane; on control-plane failure it best-effort restores appData
> - `AgentModelStore` adds `deferredSyncedModel` handling so a synced model arriving during an in-flight write is preferred over a stale confirmed value on rollback
> - [DecodedMessage+DBRepresentation.swift](https://github.com/xmtplabs/convos-ios/pull/1445/files#diff-799a177c5c150c7d17c59e9e86cfa11e57ef5b126042b380f7c166e647a167a9) and [ModelMocks.swift](https://github.com/xmtplabs/convos-ios/pull/1445/files#diff-772603937c1e0966b591b930c6c6a6d0f7a57fa42b96c828c5c471babc57c5cb) emit and render human-readable `agentModel` metadata-change rows (e.g. "switched the agent to GPT 5.6 Luna")
> - Risk: `ConversationMetadataWriterProtocol` gains a required `updateAgentModel(_:forAgent:in:)` method; all conformers (including out-of-tree test doubles) must implement it. `DBConversationMember.with(role:)` now preserves `agentModel` instead of clearing it on role changes
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f593261.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->