### PR TITLE
Make the prod debug menu row visibility reactive

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -395,10 +395,11 @@ struct AppSettingsView: View {
             isPresented: $showingEnableDebugConfirmation,
             titleVisibility: .visible
         ) {
-            // Persist the opt-in. Dismissing the dialog flips
-            // `showingEnableDebugConfirmation` back to false, which re-renders
-            // the body so `linksSection` re-reads the gate and reveals the row.
-            let enableAction = { DebugMenuFlagStore.enable() }
+            // Persist the opt-in. The flag store is observable and the body
+            // reads it through `DebugMenuGate.showsProdDebugMenu`, so the row
+            // appears (or disappears, when disabled from inside the menu)
+            // without waiting for an unrelated re-render.
+            let enableAction = { DebugMenuFlagStore.shared.enable() }
             Button("Enable", action: enableAction)
             Button("Cancel", role: .cancel) {}
         } message: {
@@ -470,7 +471,7 @@ struct AppSettingsView: View {
         // Read the persisted flag directly (not a cached copy) so a menu that
         // was disabled elsewhere can be re-enabled without relaunching.
         guard environment.isProduction else { return }
-        if DebugMenuFlagStore.isEnabled() {
+        if DebugMenuFlagStore.shared.isEnabled {
             Log.info("Version tap ignored: debug menu flag already enabled")
             return
         }

--- a/Convos/Debug View/DebugMenuFlagStore.swift
+++ b/Convos/Debug View/DebugMenuFlagStore.swift
@@ -1,5 +1,6 @@
 import ConvosCore
 import Foundation
+import Observation
 
 /// Persistent on/off flag for the curated prod debug menu.
 ///
@@ -8,26 +9,39 @@ import Foundation
 /// enabled until the user explicitly turns it off -- there is no auto-expiry
 /// and no cold-launch clear.
 ///
-/// In production the getter returns `false` unless the flag is explicitly set,
-/// mirroring the defensive posture of `FeatureFlags.isDebugInjectorEnabled`:
-/// a stray UserDefaults value leaking in from a non-prod build with the same
-/// bundle id can never silently enable the menu.
-enum DebugMenuFlagStore {
-    static func isEnabled() -> Bool {
-        UserDefaults.standard.bool(forKey: Constant.enabledKey)
+/// `isEnabled` is a computed property over UserDefaults, and the Observable
+/// macro only instruments stored properties, so the accessor registers with
+/// the observation registrar by hand -- `access(keyPath:)` in get,
+/// `withMutation(keyPath:)` around the write -- mirroring `FeatureFlags`.
+/// Views whose bodies read the flag (the App Settings "Debug menu" row via
+/// `DebugMenuGate`, and the "Debug mode" toggle inside `ProdDebugMenuView`)
+/// re-evaluate the moment it is toggled from anywhere; without the registrar
+/// calls a flip only shows up after the view is rebuilt for some other
+/// reason.
+///
+/// Every write goes through the setter so the transition is logged with a
+/// readback of the persisted value; an exported log bundle can then
+/// distinguish "enable never ran" from "write did not persist".
+@MainActor @Observable
+final class DebugMenuFlagStore {
+    static let shared: DebugMenuFlagStore = DebugMenuFlagStore()
+
+    var isEnabled: Bool {
+        get {
+            access(keyPath: \.isEnabled)
+            return UserDefaults.standard.bool(forKey: Constant.enabledKey)
+        }
+        set {
+            withMutation(keyPath: \.isEnabled) {
+                UserDefaults.standard.set(newValue, forKey: Constant.enabledKey)
+            }
+            let readback = UserDefaults.standard.bool(forKey: Constant.enabledKey)
+            Log.info("DebugMenuFlagStore: setEnabled(\(newValue)), readback=\(readback)")
+        }
     }
 
-    static func enable() {
-        setEnabled(true)
-    }
-
-    static func disable() {
-        setEnabled(false)
-    }
-
-    static func setEnabled(_ enabled: Bool) {
-        UserDefaults.standard.set(enabled, forKey: Constant.enabledKey)
-        Log.info("DebugMenuFlagStore: setEnabled(\(enabled)), readback=\(isEnabled())")
+    func enable() {
+        isEnabled = true
     }
 
     private enum Constant {

--- a/Convos/Debug View/DebugMenuGate.swift
+++ b/Convos/Debug View/DebugMenuGate.swift
@@ -19,8 +19,13 @@ enum DebugMenuGate {
     /// True when the curated prod debug menu should be reachable. In
     /// production this requires the explicit opt-in toggle; in non-prod it is
     /// always available alongside the full menu.
+    ///
+    /// Reads the observable `DebugMenuFlagStore.shared`, so a view body that
+    /// calls this re-evaluates as soon as the flag is toggled from anywhere
+    /// (the enable prompt, or the toggle inside the prod debug menu).
+    @MainActor
     static func showsProdDebugMenu(for environment: AppEnvironment) -> Bool {
         if !environment.isProduction { return true }
-        return DebugMenuFlagStore.isEnabled()
+        return DebugMenuFlagStore.shared.isEnabled
     }
 }

--- a/Convos/Debug View/ProdDebugMenuView.swift
+++ b/Convos/Debug View/ProdDebugMenuView.swift
@@ -49,7 +49,6 @@ struct ProdDebugMenuView: View {
     @State private var isExportingLogs: Bool = false
     @State private var identity: DeviceIdentitySnapshot?
     @State private var installations: InstallationsSnapshot?
-    @State private var debugModeEnabled: Bool = DebugMenuFlagStore.isEnabled()
     @State private var creditBalance: CreditBalance?
     @State private var currentSubscription: UserSubscription? = SubscriptionServices.shared.currentSubscription
 
@@ -79,10 +78,7 @@ struct ProdDebugMenuView: View {
     @ViewBuilder
     private var debugModeSection: some View {
         Section {
-            Toggle("Debug mode", isOn: $debugModeEnabled)
-                .onChange(of: debugModeEnabled) { _, newValue in
-                    DebugMenuFlagStore.setEnabled(newValue)
-                }
+            Toggle("Debug mode", isOn: Bindable(DebugMenuFlagStore.shared).isEnabled)
         } footer: {
             Text("Turn this off to hide the debug menu and clear the on-screen indicator.")
         }

--- a/ConvosTests/DebugMenuFlagStoreObservationTests.swift
+++ b/ConvosTests/DebugMenuFlagStoreObservationTests.swift
@@ -1,0 +1,71 @@
+@testable import Convos
+import Observation
+import XCTest
+
+/// The prod debug menu flag is a computed property over UserDefaults, so the
+/// accessor registers with the observation registrar by hand (same pattern as
+/// `FeatureFlags`, pinned by `FeatureFlagsObservationTests`). These tests pin
+/// that wiring: the App Settings "Debug menu" row and the "Debug mode" toggle
+/// inside the menu read the flag in their bodies and must be invalidated the
+/// moment it is toggled from either place. They also pin the persistence key,
+/// which existing devices already carry.
+@MainActor
+final class DebugMenuFlagStoreObservationTests: XCTestCase {
+    private let key = "convos.debugMenu.enabled.v1"
+
+    func testDefaultsOffPersistsUnderStableKeyAndNotifiesObservers() {
+        let defaults = UserDefaults.standard
+        let original = defaults.object(forKey: key)
+        defer {
+            if let original {
+                defaults.set(original, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+        defaults.removeObject(forKey: key)
+
+        let store = DebugMenuFlagStore.shared
+        XCTAssertFalse(store.isEnabled)
+
+        let changed = expectation(description: "Debug menu flag observation fired")
+        withObservationTracking {
+            _ = store.isEnabled
+        } onChange: {
+            changed.fulfill()
+        }
+
+        store.enable()
+        wait(for: [changed], timeout: 1.0)
+        XCTAssertTrue(defaults.bool(forKey: key))
+        XCTAssertTrue(store.isEnabled)
+    }
+
+    func testDisablingNotifiesObserversAndRoundTrips() {
+        let defaults = UserDefaults.standard
+        let original = defaults.object(forKey: key)
+        defer {
+            if let original {
+                defaults.set(original, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+
+        let store = DebugMenuFlagStore.shared
+        store.isEnabled = true
+        XCTAssertTrue(store.isEnabled)
+
+        let changed = expectation(description: "Debug menu flag disable observation fired")
+        withObservationTracking {
+            _ = store.isEnabled
+        } onChange: {
+            changed.fulfill()
+        }
+
+        store.isEnabled = false
+        wait(for: [changed], timeout: 1.0)
+        XCTAssertFalse(defaults.bool(forKey: key))
+        XCTAssertFalse(store.isEnabled)
+    }
+}


### PR DESCRIPTION
Follow-up to #1444 (merged with the diagnostics only — this commit was built on that branch but landed after the merge).

Fixes the latent non-reactive gate found during the debug-menu investigation: the App Settings row read `DebugMenuFlagStore` via a plain UserDefaults call, so enabling via the 7-tap prompt only looked reactive through the dialog-dismissal re-render, and disabling from inside the menu left a stale row.

- `DebugMenuFlagStore` becomes a `@MainActor @Observable` shared class using the `FeatureFlags` registrar pattern (`access`/`withMutation` over UserDefaults). The persistence key `convos.debugMenu.enabled.v1` is unchanged so existing devices keep their state, and #1444's diagnostic readback stays in the setter.
- All readers rewired: the row appears the moment the prompt enables the menu, and turning off "Debug mode" inside `ProdDebugMenuView` removes the row immediately on navigating back (the local `@State` copy is gone; the toggle binds to the shared source of truth).
- Pinned by `DebugMenuFlagStoreObservationTests` (observation fires + value round-trips), mutation-checked: removing the registrar call fails the test.

Verified on the original branch: SwiftLint --strict clean, Convos (Dev) build clean, targeted tests pass on simulator; app-target only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790368091&installation_model_id=20076&pr_number=1446&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1446&signature=1359b2997d1f74da6a3f9aa36ab6dd5221d0458c8cbd693173aff9fa8417e990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make prod debug menu row visibility reactive via observable `DebugMenuFlagStore`
> - Refactors `DebugMenuFlagStore` from a static enum into a `@MainActor @Observable final class` with a `shared` singleton, so views tracking `isEnabled` invalidate immediately on toggle
> - Updates `AppSettingsView`, `DebugMenuGate`, and `ProdDebugMenuView` to read and bind against the observable singleton instead of the removed static API
> - `ProdDebugMenuView` removes its local `@State` mirror and binds the toggle directly to `Bindable(DebugMenuFlagStore.shared).isEnabled`
> - Adds `DebugMenuFlagStoreObservationTests` covering persistence-key stability and observer notification on toggle
> - Risk: all static methods (`isEnabled()`, `enable()`, `disable()`, `setEnabled(_:)`) are removed; any out-of-tree callers of the old static API will fail to compile
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa86707.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->