### PR TITLE
Wire the join-request poll to invite shares

### DIFF
--- a/Convos/Contacts/AddFromContactsPickerModifier.swift
+++ b/Convos/Contacts/AddFromContactsPickerModifier.swift
@@ -94,7 +94,8 @@ private struct AddFromContactsPickerModifier: ViewModifier {
                     completed: completed,
                     invite: viewModel.invite,
                     conversation: viewModel.conversation,
-                    coreActions: viewModel.coreActions
+                    coreActions: viewModel.coreActions,
+                    session: viewModel.session
                 )
                 if completed { onInviteShared?() }
             }
@@ -106,6 +107,7 @@ private struct AddFromContactsPickerModifier: ViewModifier {
             InviteCodeSheet(
                 conversation: viewModel.conversation,
                 invite: viewModel.invite,
+                session: viewModel.session,
                 onShareCompleted: { completed in
                     if completed { onInviteShared?() }
                 }

--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -437,13 +437,16 @@ struct ContactsView: View {
     private func handleInviteShareCompleted(activityType: UIActivity.ActivityType?, completed: Bool) {
         guard let sharedViewModel = sharedInviteViewModel else { return }
         sharedInviteViewModel = nil
-        if let sharedInvite {
+        // A nil session can't have produced an invite to share in the first
+        // place - the invite rows only appear with a live one.
+        if let sharedInvite, let session {
             ConversationShareReporter.report(
                 activityType: activityType,
                 completed: completed,
                 invite: sharedInvite,
                 conversation: sharedViewModel.conversationViewModel?.conversation,
-                coreActions: coreActions
+                coreActions: coreActions,
+                session: session
             )
         }
         sharedInvite = nil

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -117,7 +117,8 @@ struct ConversationInfoView: View {
                 completed: completed,
                 invite: viewModel.invite,
                 conversation: viewModel.conversation,
-                coreActions: viewModel.coreActions
+                coreActions: viewModel.coreActions,
+                session: viewModel.session
             )
         }
     }
@@ -640,7 +641,8 @@ struct ConversationInfoView: View {
                 .sheet(isPresented: $presentingInviteCode) {
                     InviteCodeSheet(
                         conversation: viewModel.conversation,
-                        invite: viewModel.invite
+                        invite: viewModel.invite,
+                        session: viewModel.session
                     )
                 }
                 .background {

--- a/Convos/Conversation Detail/ConversationMembersListView.swift
+++ b/Convos/Conversation Detail/ConversationMembersListView.swift
@@ -25,7 +25,8 @@ struct ConversationMembersListView: View {
                 completed: completed,
                 invite: viewModel.invite,
                 conversation: viewModel.conversation,
-                coreActions: viewModel.coreActions
+                coreActions: viewModel.coreActions,
+                session: viewModel.session
             )
         }
     }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1272,7 +1272,8 @@ private extension ConversationView {
                 completed: completed,
                 invite: viewModel.invite,
                 conversation: viewModel.conversation,
-                coreActions: viewModel.coreActions
+                coreActions: viewModel.coreActions,
+                session: viewModel.session
             )
             guard completed else { return }
             onInviteShared?()

--- a/Convos/Conversation Detail/InviteCodeSheet.swift
+++ b/Convos/Conversation Detail/InviteCodeSheet.swift
@@ -17,6 +17,9 @@ import SwiftUI
 struct InviteCodeSheet: View {
     let conversation: Conversation
     let invite: Invite
+    /// Used to watch for a join request the message stream never delivers
+    /// while this code is on screen. See `startJoinRequestPolling`.
+    let session: any SessionManagerProtocol
     /// Fires when a share completes, so a caller minting a conversation just
     /// to share its code can record that the link is out in the world.
     var onShareCompleted: ((Bool) -> Void)?
@@ -46,9 +49,28 @@ struct InviteCodeSheet: View {
                 }
             }
         }
+        .onAppear(perform: startJoinRequestPolling)
+    }
+
+    /// A code on screen is an invitation someone may be scanning right now,
+    /// and their join request arrives as a DM in a brand new conversation -
+    /// a topic with no push subscription, so the message stream is the only
+    /// live path that carries it. Watch for one the stream misses, rather
+    /// than leaving the scanner on "Verifying" until it times out.
+    private func startJoinRequestPolling() {
+        guard !invite.isEmpty else { return }
+        Task {
+            await session.messagingService()
+                .sessionStateManager
+                .startJoinRequestPolling(reason: .inviteShared)
+        }
     }
 }
 
 #Preview {
-    InviteCodeSheet(conversation: .mock(), invite: .mock())
+    InviteCodeSheet(
+        conversation: .mock(),
+        invite: .mock(),
+        session: ConvosClient.mock().session
+    )
 }

--- a/Convos/Metrics/ConversationShareReporter.swift
+++ b/Convos/Metrics/ConversationShareReporter.swift
@@ -35,10 +35,13 @@ enum ConversationShareReporter {
         completed: Bool,
         invite: Invite,
         conversation: Conversation?,
-        coreActions: any CoreActions
+        coreActions: any CoreActions,
+        session: any SessionManagerProtocol
     ) {
         // Nothing was shareable, so the sheet carried no invite.
         guard !invite.isEmpty else { return }
+
+        startJoinRequestPollingIfShared(completed: completed, session: session)
 
         let target: ShareTarget = shareTarget(for: activityType, completed: completed)
         let memberCount: Int = conversation?.members.count ?? 0
@@ -55,6 +58,29 @@ enum ConversationShareReporter {
                 expiresAfterUse: expiresAfterUse,
                 isSuccess: completed
             )
+        }
+    }
+
+    /// Starts the bounded join-request poll once an invite actually reaches
+    /// someone.
+    ///
+    /// The invite is out in the world now, so a join request may arrive over
+    /// the next couple of minutes. It reaches this device as a DM in a brand
+    /// new conversation - a topic with no push subscription - so the message
+    /// stream is the only live path that carries it. When that stream is
+    /// silently delivering nothing, the poll is what admits the joiner
+    /// instead of leaving them on "Verifying" until it times out.
+    ///
+    /// A cancelled share reached nobody, so it starts nothing.
+    static func startJoinRequestPollingIfShared(
+        completed: Bool,
+        session: any SessionManagerProtocol
+    ) {
+        guard completed else { return }
+        Task {
+            await session.messagingService()
+                .sessionStateManager
+                .startJoinRequestPolling(reason: .inviteShared)
         }
     }
 }

--- a/Convos/Shared Views/ConversationPresenter.swift
+++ b/Convos/Shared Views/ConversationPresenter.swift
@@ -97,7 +97,11 @@ struct ConversationPresenter<Content: View>: View {
         }
         .sheet(isPresented: inviteCodeBinding) {
             if let viewModel {
-                InviteCodeSheet(conversation: viewModel.conversation, invite: viewModel.invite)
+                InviteCodeSheet(
+                    conversation: viewModel.conversation,
+                    invite: viewModel.invite,
+                    session: viewModel.session
+                )
             }
         }
         .dynamicTypeSize(...DynamicTypeSize.xxxLarge)

--- a/ConvosCore/Sources/ConvosCore/Inboxes/FailedIdentityLoadOperation.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/FailedIdentityLoadOperation.swift
@@ -50,7 +50,7 @@ final class FailedIdentityLoadSessionStateManager: SessionStateManagerProtocol, 
 
     func runHistorySyncBackfill() async {}
 
-    func startAgentJoinRequestPolling() async {}
+    func startJoinRequestPolling(reason: JoinRequestPollReason) async {}
 
     func addObserver(_ observer: SessionStateObserver) {
         observer.sessionStateDidChange(currentState)

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -392,9 +392,9 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
         await syncingManager.requestDiscovery()
     }
 
-    public func startAgentJoinRequestPolling() async {
+    public func startJoinRequestPolling(reason: JoinRequestPollReason) async {
         guard let syncingManager else { return }
-        await syncingManager.startAgentJoinRequestPolling()
+        await syncingManager.startJoinRequestPolling(reason: reason)
     }
 
     /// `nonisolated` so the non-Sendable client obtained from

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateManager.swift
@@ -24,8 +24,8 @@ public protocol SessionStateManagerProtocol: AnyObject, Sendable {
 
     /// Temporary diagnostic for agents timing out while joining. Starts a
     /// bounded poll for unprocessed join-request DMs in case the message
-    /// stream has died. See `SyncingManager.startAgentJoinRequestPolling`.
-    func startAgentJoinRequestPolling() async
+    /// stream has died. See `SyncingManager.startJoinRequestPolling`.
+    func startJoinRequestPolling(reason: JoinRequestPollReason) async
 
     func addObserver(_ observer: SessionStateObserver)
     func removeObserver(_ observer: SessionStateObserver)

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockSessionStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockSessionStateManager.swift
@@ -46,7 +46,7 @@ public final class MockSessionStateManager: SessionStateManagerProtocol, @unchec
     public func runHistorySyncBackfill() async {
     }
 
-    public func startAgentJoinRequestPolling() async {
+    public func startJoinRequestPolling(reason: JoinRequestPollReason) async {
     }
 
     public func addObserver(_ observer: any SessionStateObserver) {

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -17,12 +17,15 @@ public protocol SyncingManagerProtocol: Actor {
     func setInviteJoinErrorHandler(_ handler: (any InviteJoinErrorHandler)?) async
     func setTypingIndicatorHandler(_ handler: @escaping @Sendable (String, String, Bool) -> Void) async
 
-    /// Temporary diagnostic for agents timing out while joining (suspected
-    /// silent message-stream death). Polls for unprocessed join-request DMs
-    /// for a bounded window after an agents/join call, processing anything
-    /// the stream missed. Remove once the stream issue is confirmed and
-    /// fixed. See `SyncingManager.startAgentJoinRequestPolling`.
-    func startAgentJoinRequestPolling() async
+    /// Safety net for a join request the message stream never delivered.
+    /// Polls for unprocessed join-request DMs for a bounded window after the
+    /// user does something that invites someone, processing anything the
+    /// stream missed. See `SyncingManager.startJoinRequestPolling`.
+    ///
+    /// The stream dying loudly is handled by the state machine, which now
+    /// restarts on `.resume`. This covers the case it cannot see: a stream
+    /// that is nominally alive and silently delivering nothing.
+    func startJoinRequestPolling(reason: JoinRequestPollReason) async
 
     /// Drain the backlog of activity since `cursor` in one batched transaction,
     /// before streams resume. Runs the message-side `BatchCatchUp` and the
@@ -81,6 +84,27 @@ private struct UncheckedClientBox: @unchecked Sendable {
 /// manage lifecycle transitions and ensure proper sequencing of operations.
 enum SyncingError: Error {
     case streamRetriesExhausted
+}
+
+/// What prompted a join-request poll. The poll itself is identical either
+/// way - `processJoinRequestOutcomes` has never been agent-specific - but a
+/// rescue means something different depending on who was kept waiting, so
+/// the two report separately.
+public enum JoinRequestPollReason: Sendable {
+    /// The user asked an assistant to join. The assistant polls the network
+    /// and gives up after 60s.
+    case assistantJoin
+    /// The user surfaced an invite - shared the link or put the code on
+    /// screen - so a person may be trying to join right now. They watch
+    /// "Verifying" for 150s before it times out.
+    case inviteShared
+
+    var logLabel: String {
+        switch self {
+        case .assistantJoin: return "assistant-join"
+        case .inviteShared: return "invite-shared"
+        }
+    }
 }
 
 // swiftlint:disable:next type_body_length
@@ -153,7 +177,7 @@ actor SyncingManager: SyncingManagerProtocol {
     /// Temporary diagnostic state for the agent-join poll. The task is the
     /// bounded polling loop; the date stamps the last message the stream
     /// actually delivered, so poll logs can report how stale the stream is.
-    private var agentJoinPollTask: Task<Void, Never>?
+    private var joinRequestPollTask: Task<Void, Never>?
     private var lastMessageStreamEventDate: Date?
 
     /// Reconciles conversation consent against contact-block state (the
@@ -261,7 +285,7 @@ actor SyncingManager: SyncingManagerProtocol {
         notificationTask?.cancel()
         messageStreamTask?.cancel()
         conversationStreamTask?.cancel()
-        agentJoinPollTask?.cancel()
+        joinRequestPollTask?.cancel()
         currentTask?.cancel()
 
         // Remove observers
@@ -1003,7 +1027,7 @@ actor SyncingManager: SyncingManagerProtocol {
         syncTask?.cancel()
         messageStreamTask?.cancel()
         conversationStreamTask?.cancel()
-        agentJoinPollTask?.cancel()
+        joinRequestPollTask?.cancel()
 
         if let task = syncTask {
             _ = await task.value
@@ -1017,9 +1041,9 @@ actor SyncingManager: SyncingManagerProtocol {
             _ = await task.value
             conversationStreamTask = nil
         }
-        if let task = agentJoinPollTask {
+        if let task = joinRequestPollTask {
             _ = await task.value
-            agentJoinPollTask = nil
+            joinRequestPollTask = nil
         }
     }
 
@@ -1209,52 +1233,65 @@ extension SyncingManager {
     /// coordinator returns `.alreadyMember` (no re-add, no duplicate
     /// snapshot), which also keeps the "stream missed it" log signal free
     /// of false positives.
-    func startAgentJoinRequestPolling() {
-        agentJoinPollTask?.cancel()
+    func startJoinRequestPolling(reason: JoinRequestPollReason) {
+        // A second trigger inside an in-flight window (sharing a link right
+        // after showing the code, say) rebases the window rather than
+        // running two loops over the same DMs.
+        joinRequestPollTask?.cancel()
         let startedAt = Date()
-        Log.info("[agent-join-poll] starting: every \(Int(Constant.agentJoinPollInterval))s for \(Int(Constant.agentJoinPollWindow))s")
-        agentJoinPollTask = Task { [weak self] in
-            await self?.runAgentJoinRequestPolling(startedAt: startedAt)
+        Log.info("[join-poll] starting (\(reason.logLabel)): every \(Int(Constant.joinPollInterval))s for \(Int(Constant.joinPollWindow))s")
+        joinRequestPollTask = Task { [weak self] in
+            await self?.runJoinRequestPolling(startedAt: startedAt, reason: reason)
         }
     }
 
-    private func runAgentJoinRequestPolling(startedAt: Date) async {
-        var cursor = startedAt.addingTimeInterval(-Constant.agentJoinPollCursorOverlap)
-        let deadline = startedAt.addingTimeInterval(Constant.agentJoinPollWindow)
+    private func runJoinRequestPolling(startedAt: Date, reason: JoinRequestPollReason) async {
+        var cursor = startedAt.addingTimeInterval(-Constant.joinPollCursorOverlap)
+        let deadline = startedAt.addingTimeInterval(Constant.joinPollWindow)
         var tick = 0
         while !Task.isCancelled && Date() < deadline {
             do {
-                try await Task.sleep(nanoseconds: UInt64(Constant.agentJoinPollInterval * 1_000_000_000))
+                try await Task.sleep(nanoseconds: UInt64(Constant.joinPollInterval * 1_000_000_000))
             } catch {
                 break
             }
             tick += 1
             guard case .ready(let params) = _state else {
-                Log.debug("[agent-join-poll] tick \(tick) skipped - sync not ready (\(_state))")
+                Log.debug("[join-poll] tick \(tick) skipped - sync not ready (\(_state))")
                 continue
             }
             let tickStartedAt = Date()
             do {
                 _ = try await params.client.conversationsProvider.syncAllConversations(consentStates: params.consentStates)
             } catch {
-                Log.warning("[agent-join-poll] tick \(tick): syncAllConversations failed, will retry: \(error)")
+                Log.warning("[join-poll] tick \(tick): syncAllConversations failed, will retry: \(error)")
                 continue
             }
-            let acceptedCount = await runAgentJoinPollBatch(params: params, since: cursor)
+            let acceptedCount = await runJoinPollBatch(params: params, since: cursor)
             if acceptedCount > 0 {
                 let streamAgeSecs: Float = lastMessageStreamEventDate.map { Float(Date().timeIntervalSince($0)) } ?? -1
                 let lastStreamEvent: String = streamAgeSecs >= 0 ? "\(Int(streamAgeSecs))s ago" : "never"
                 Log.warning(
-                    "[agent-join-poll] tick \(tick): accepted \(acceptedCount) join request(s) the message stream had not processed" +
+                    "[join-poll] tick \(tick) (\(reason.logLabel)): accepted \(acceptedCount) join request(s) the message stream had not processed" +
                     " (last stream message: \(lastStreamEvent)) - message stream is likely dead"
                 )
-                await coreActions.assistantJoinRescuedByPolling(streamAgeSecs: streamAgeSecs, pollTick: tick)
+                switch reason {
+                case .assistantJoin:
+                    await coreActions.assistantJoinRescuedByPolling(streamAgeSecs: streamAgeSecs, pollTick: tick)
+                case .inviteShared:
+                    // `assistantJoinRescuedByPolling` is the only rescue metric
+                    // the shared catalog defines, and reporting a person's join
+                    // through it would silently corrupt the assistant funnel.
+                    // Invite rescues are warning-logged above until the catalog
+                    // gains a matching event.
+                    break
+                }
             } else {
-                Log.debug("[agent-join-poll] tick \(tick): no unprocessed join requests")
+                Log.debug("[join-poll] tick \(tick): no unprocessed join requests")
             }
-            cursor = tickStartedAt.addingTimeInterval(-Constant.agentJoinPollCursorOverlap)
+            cursor = tickStartedAt.addingTimeInterval(-Constant.joinPollCursorOverlap)
         }
-        Log.info("[agent-join-poll] finished after \(tick) tick(s)")
+        Log.info("[join-poll] finished after \(tick) tick(s)")
     }
 
     /// Processes join-request DMs since `since`, then pulls the message-side
@@ -1268,7 +1305,7 @@ extension SyncingManager {
     /// state it touches is the immutable `identityStore` / `databaseWriter`,
     /// and it keeps the non-Sendable client out of the actor's isolation
     /// domain.
-    private nonisolated func runAgentJoinPollBatch(params: SyncClientParams, since: Date?) async -> Int {
+    private nonisolated func runJoinPollBatch(params: SyncClientParams, since: Date?) async -> Int {
         let client = params.client
         let manager = InviteJoinRequestsManager(
             identityStore: identityStore,
@@ -1296,15 +1333,15 @@ extension SyncingManager {
         static let maxConcurrentDiscoverPrechecks: Int = 4
         /// How often the temporary agent-join poll checks for unprocessed
         /// join requests.
-        static let agentJoinPollInterval: TimeInterval = 5
+        static let joinPollInterval: TimeInterval = 5
         /// How long the poll keeps checking after an agents/join call. The
         /// agent backend gives up after about two minutes; poll a bit past
         /// that so the tail end of the window is still observable.
-        static let agentJoinPollWindow: TimeInterval = 150
+        static let joinPollWindow: TimeInterval = 150
         /// Back-overlap applied when advancing the poll cursor so messages
         /// that land while a sync pass is in flight aren't skipped by the
         /// next tick.
-        static let agentJoinPollCursorOverlap: TimeInterval = 5
+        static let joinPollCursorOverlap: TimeInterval = 5
     }
 }
 

--- a/ConvosCore/Tests/ConvosCoreIntegrationTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreIntegrationTests/TestHelpers.swift
@@ -340,7 +340,7 @@ actor MockSyncingManager: SyncingManagerProtocol {
     func setInviteJoinErrorHandler(_ handler: (any InviteJoinErrorHandler)?) async {
     }
 
-    func startAgentJoinRequestPolling() {
+    func startJoinRequestPolling(reason: JoinRequestPollReason) {
     }
 
     func setTypingIndicatorHandler(_ handler: @escaping @Sendable (String, String, Bool) -> Void) async {

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationConsentWriterDeleteTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationConsentWriterDeleteTests.swift
@@ -236,7 +236,7 @@ private final class InboxUnavailableSessionStateManager: SessionStateManagerProt
     func setTypingIndicatorHandler(_ handler: @escaping @Sendable (String, String, Bool) -> Void) async {}
     func requestDiscovery() async {}
     func runHistorySyncBackfill() async {}
-    func startAgentJoinRequestPolling() async {}
+    func startJoinRequestPolling(reason: JoinRequestPollReason) async {}
     func addObserver(_ observer: SessionStateObserver) {}
     func removeObserver(_ observer: SessionStateObserver) {}
 

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -1400,4 +1400,54 @@ struct SyncingManagerTests {
         await syncingManager.stop()
         try? await fixtures.cleanup()
     }
+
+    /// The invite-side wiring for the join-request poll. A join request lands
+    /// as a DM in a brand new conversation - a topic with no push
+    /// subscription - so the message stream is the only live path that
+    /// carries it. When the stream is silently delivering nothing, this poll
+    /// is what admits the joiner instead of leaving them on "Verifying".
+    ///
+    /// Asserts the loop actually runs: each tick syncs before scanning for
+    /// unprocessed join requests, so a rising sync count is the observable
+    /// proof the poll is wired and ticking.
+    @Test("Invite-shared polling keeps scanning while the session is ready")
+    func testInviteJoinRequestPollingRunsWhileReady() async throws {
+        let fixtures = TestFixtures()
+        let mockClient = TestableMockClient()
+        mockClient.streamBehavior = .neverClose
+        let mockAPIClient = TestableMockAPIClient()
+
+        let syncingManager = SyncingManager(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            deviceRegistrationManager: nil,
+            notificationCenter: MockUserNotificationCenter(),
+            coreActions: NoOpCoreActions()
+        )
+
+        await syncingManager.start(with: mockClient, apiClient: mockAPIClient)
+        try await waitUntil(timeout: .seconds(10)) {
+            await syncingManager.isSyncReady
+        }
+
+        let provider = mockClient.conversationsProvider as? TestableMockConversations
+        let syncsBeforePolling: Int = provider?.syncCallCount ?? 0
+
+        await syncingManager.startJoinRequestPolling(reason: .inviteShared)
+
+        try await waitUntil(timeout: .seconds(30)) {
+            (provider?.syncCallCount ?? 0) > syncsBeforePolling
+        }
+
+        let syncsAfterPolling: Int = provider?.syncCallCount ?? 0
+        #expect(
+            syncsAfterPolling > syncsBeforePolling,
+            "Each poll tick should sync before scanning for unprocessed join requests"
+        )
+
+        // Clean up
+        await syncingManager.stop()
+        try? await fixtures.cleanup()
+    }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
@@ -314,7 +314,7 @@ actor MockSyncingManager: SyncingManagerProtocol {
     func setInviteJoinErrorHandler(_ handler: (any InviteJoinErrorHandler)?) async {
     }
 
-    func startAgentJoinRequestPolling() {
+    func startJoinRequestPolling(reason: JoinRequestPollReason) {
     }
 
     func setTypingIndicatorHandler(_ handler: @escaping @Sendable (String, String, Bool) -> Void) async {


### PR DESCRIPTION
Follow-up to #1340. That fix made a *loudly* dead stream recoverable — the state machine now restarts on `.resume`. This covers what it cannot see: a stream that is nominally alive and silently delivering nothing.

## The dead code

`startAgentJoinRequestPolling` has been in the tree since the assistant join timeouts were investigated, annotated as a diagnostic for *"suspected silent message-stream death"*. It has **never had a production caller** — only mocks and test doubles. The fallback it implements has never once run.

Its loop was never agent-specific. `processJoinRequestOutcomes` processes whatever join-request DMs are unprocessed, and a person joining by invite is the same shape as an assistant joining: they DM the creator and wait to be added. Only the name and the rescue metric were agent-flavoured.

## Why invites need it most

The invite path has no second chance. A join request arrives as a DM in a **brand new conversation** — a topic the creator has no push subscription for. The push handler already says so:

> "with no topic subscription for the new DM there may be no second push."

So the message stream is the only live path that carries it. Miss it and the joiner watches "Verifying" for 150s and gives up. Once the request ages past `maxCatchUpWindow` (24h), no later catch-up reaches back far enough either — **the invite is missed permanently**.

This is also why an affected user still receives messages normally while nobody can join: pushes keep arriving on topics they're already subscribed to, and only the join path is starved.

## What this wires

Renames to `startJoinRequestPolling(reason:)` with a `JoinRequestPollReason`, so the two callers stay legible in logs and route their own telemetry.

Two triggers, both on the creator's device:

- **Sharing an invite** — via `ConversationShareReporter`. All five share surfaces already route through it (#1429), so one hook covers them all. A cancelled share reached nobody and starts nothing.
- **Showing the invite code** — via `InviteCodeSheet.onAppear`. A code on screen is an invitation someone may be scanning right now, and that path never opens a share sheet.

`session` is a **required** parameter on `report(...)` rather than an optional with a default, so a future share surface cannot silently opt out of the safety net. A second trigger inside an in-flight window rebases it rather than running two loops over the same DMs.

## Telemetry

`.assistantJoin` keeps reporting through `assistantJoinRescuedByPolling`. `.inviteShared` warning-logs instead: that metric is defined in **convos-shared**, and reporting a person's join through the assistant event would corrupt that funnel. Adding a matching event to the shared catalog is a follow-up — deliberately not bundled here so this PR stays inside convos-ios.

## Testing

- New test asserts the loop actually runs under `.inviteShared`: each tick syncs before scanning, so a rising sync count is the observable proof it is wired and ticking. Passes in ~5s; log confirms `[join-poll] starting (invite-shared)`.
- Full unit suite: **1957 tests / 247 suites pass**.
- `swift build` clean, app target (`Convos (Dev)`) builds, SwiftLint clean.

Asserting on a real rescue needs live XMTP data and belongs in the integration target.

## Checked against #1429

No overlap on the polling mechanism — #1429 touched telemetry only and never went near `SyncingManager`. It did refactor the five invite share surfaces and centralise them behind `ConversationShareReporter`, which is what made the single share hook here possible.

> [!NOTE]
> The commit is unsigned — the 1Password agent was locked again and signing failed with `failed to fill whole buffer`. Happy to re-sign as with #1340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790369395&installation_model_id=20076&pr_number=1448&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1448&signature=60db005b2008da522d73cbfe3dce68f9595eaec6b90214d78e23705004d1006c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Start join-request poll on invite shares via `ConversationShareReporter` and `InviteCodeSheet`
> - After a successful invite share, `ConversationShareReporter.report` now calls `startJoinRequestPolling(reason: .inviteShared)` through the passed `session`, so downstream polling runs alongside metrics reporting.
> - `InviteCodeSheet` accepts a `session` and starts the same bounded poll loop on `.onAppear` when an invite is present; all call sites updated to pass `session: viewModel.session`.
> - Renames the temporary API `startAgentJoinRequestPolling()` to `startJoinRequestPolling(reason: JoinRequestPollReason)` across `SyncingManagerProtocol`, `SessionStateManagerProtocol`, and all conformers, introducing the `JoinRequestPollReason` enum with `assistantJoin` and `inviteShared` cases.
> - The poll loop in `SyncingManager.runJoinRequestPolling` is generalized for both reasons; `assistantJoinRescuedByPolling` metrics now emit only for `.assistantJoin` while `.inviteShared` only logs.
> - Risk: `SyncingManager.startJoinRequestPolling` cancels any in-flight poll and rebases the window when retriggered, so rapid back-to-back invite shares from different entry points could interrupt an earlier poll cycle before it completes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b1edde.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->