### PR TITLE
refactor(conversations): no-op redundant same-tab switch requests

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -430,7 +430,8 @@ struct ConversationView<MessagesBottomBar: View>: View {
               conversationId == viewModel.conversation.id,
               let rawTab = note.userInfo?["tab"] as? String,
               let tab = ConversationTab(rawValue: rawTab),
-              availableTabs.contains(tab) else {
+              availableTabs.contains(tab),
+              tab != selectedTab else {
             return
         }
         selectTab(tab)


### PR DESCRIPTION
Follow-up to #1434 addressing the tab-switch review feedback: `handleSelectConversationTabRequest` now also guards on `tab != selectedTab`, so a `.selectConversationTabRequested` notification asking for the tab already on screen is an explicit no-op (matching `seedInitialTabIfNeeded`). The other two review notes needed no change — the post is main-actor isolated via the `@MainActor` view model, and the handler already validates the conversation id, the tab's raw value, and `availableTabs` membership before switching.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790373605&installation_model_id=20076&pr_number=1449&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1449&signature=40de5fe1199e68e940e83c416c06dae0f91cf50b196e838eedddc58679e33ec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip `selectTab` in `ConversationView.handleSelectConversationTabRequest` when tab is unchanged
> Adds a `tab != selectedTab` check to the guard condition in the notification handler, so same-tab requests become a no-op. This prevents a redundant `selectTab` call and its downstream `onChange(of: selectedTab)` side effects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f1b1fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->