### PR TITLE
refactor(connections): clean up Connections list and detail UI

### DIFF
--- a/Convos/Abilities/AbilitiesListView.swift
+++ b/Convos/Abilities/AbilitiesListView.swift
@@ -165,8 +165,9 @@ struct AbilitiesListScreen: View {
 /// and takes the `ConnectionsBrowserMode` naming the caller):
 /// - App Settings connections row (`AppSettingsView.connectionsDestination`)
 ///   pushes it in mode `.appSettings`; the row is titled "Abilities". Account
-///   level throughout: "Connected" / "All connections" / "Status unknown",
-///   the `ellipsis` menu with Disconnect, and the detail push.
+///   level throughout: "Connected" / "Add a connection" / "Status unknown",
+///   each Connected row pushing the detail (where Disconnect lives) and each
+///   available row connecting on tap.
 /// - The agent composer's `+` menu presents it full-screen from
 ///   `ConversationView.connectionsBrowserPresentation`, in mode
 ///   `.composerModal`; the screen then supplies its own `NavigationStack`
@@ -383,11 +384,11 @@ struct AbilitiesListView: View {
         }
     }
 
-    /// The account-level list enumerates what exists; the chat-scoped one
-    /// frames the same rows as things to add to this convo.
+    /// Both frame the rows as things to add; the account-level list adds to
+    /// the account, the chat-scoped one to this convo.
     private var availableSectionTitle: String {
         switch mode {
-        case .appSettings: "All connections"
+        case .appSettings: "Add a connection"
         case .composerModal: "Discover"
         }
     }
@@ -426,7 +427,12 @@ struct AbilitiesListView: View {
 
     private func navigableEntitledRow(_ ability: AbilitiesAPI.Ability) -> some View {
         NavigationLink {
-            AbilityDetailScreen(ability: ability, usageSource: usageSource)
+            AbilityDetailScreen(
+                ability: ability,
+                usageSource: usageSource,
+                onDisconnect: { viewModel.disconnect(ability) },
+                onReconnect: { viewModel.connect(ability) }
+            )
         } label: {
             abilityRowContent(ability, subtitle: entitledSubtitle(for: ability)) {
                 entitledAccessory(ability)
@@ -505,9 +511,38 @@ struct AbilitiesListView: View {
         .accessibilityIdentifier("ability-disclosure-\(ability.id)")
     }
 
+    @ViewBuilder
     private func availableRow(_ ability: AbilitiesAPI.Ability) -> some View {
-        abilityRowContent(ability, subtitle: ability.subtitle.resolved()) {
-            availableAccessory(ability)
+        switch mode {
+        case .appSettings:
+            connectableAvailableRow(ability)
+        case .composerModal:
+            abilityRowContent(ability, subtitle: ability.subtitle.resolved()) {
+                availableAccessory(ability)
+            }
+        }
+    }
+
+    /// App Settings frames each available connection as a single Connect
+    /// action: the whole row is the button, so there is no inline Connect
+    /// control. A spinner takes the trailing space while the connect runs.
+    private func connectableAvailableRow(_ ability: AbilitiesAPI.Ability) -> some View {
+        let connectAction: () -> Void = { viewModel.connect(ability) }
+        return Button(action: connectAction) {
+            abilityRowContent(ability, subtitle: ability.subtitle.resolved()) {
+                availableBusyAccessory(ability)
+            }
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .disabled(viewModel.isBusy(ability))
+        .accessibilityIdentifier("ability-connect-\(ability.id)")
+    }
+
+    @ViewBuilder
+    private func availableBusyAccessory(_ ability: AbilitiesAPI.Ability) -> some View {
+        if viewModel.isBusy(ability) {
+            ProgressView()
         }
     }
 
@@ -587,9 +622,14 @@ struct AbilitiesListView: View {
         if viewModel.isBusy(ability) {
             ProgressView()
         } else if let entitlement = ability.entitlement {
-            HStack(spacing: DesignConstants.Spacing.step2x) {
+            // Active connections need no accessory: the row reads clean and the
+            // chevron already says it opens. Broken states keep their badge as
+            // the warning that something needs attention.
+            switch entitlement.status {
+            case .active:
+                EmptyView()
+            default:
                 AbilityStatusBadge(status: entitlement.status)
-                entitledMenu(ability, status: entitlement.status)
             }
         }
     }
@@ -632,30 +672,6 @@ struct AbilitiesListView: View {
         } else {
             ConversationAbilityToggleLoadingControl()
         }
-    }
-
-    private func entitledMenu(_ ability: AbilitiesAPI.Ability, status: AbilitiesAPI.EntitlementStatus) -> some View {
-        let continueAction = { viewModel.connect(ability) }
-        let disconnectAction = { viewModel.disconnect(ability) }
-        return Menu {
-            switch status {
-            case .expired, .needsReauth, .revoked:
-                Button("Reconnect", action: continueAction)
-            case .active, .pendingAuth:
-                // `pendingAuth` never reaches this menu: an unfinished
-                // authorization is a Discover row with a Connect button,
-                // not a Connected row with a repair entry.
-                EmptyView()
-            }
-            Button("Disconnect", role: .destructive, action: disconnectAction)
-        } label: {
-            Image(systemName: "ellipsis")
-                .font(.body)
-                .foregroundStyle(.colorTextSecondary)
-                .frame(width: DesignConstants.Spacing.step6x, height: DesignConstants.Spacing.step6x)
-                .contentShape(.rect)
-        }
-        .accessibilityIdentifier("ability-menu-\(ability.id)")
     }
 
     @ViewBuilder

--- a/Convos/Abilities/AbilitiesListViewModel.swift
+++ b/Convos/Abilities/AbilitiesListViewModel.swift
@@ -158,10 +158,15 @@ final class AbilitiesListViewModel {
     /// Connect opens a fresh round - the only action that can actually
     /// finish the job.
     ///
-    /// Everything else that is entitled stays Connected: `expired`,
-    /// `needsReauth` and `revoked` all describe a connection that did exist
-    /// and can be repaired in place, and the badge beside them is what
-    /// tells the member what to fix.
+    /// `revoked` joins it in Discover for the mirror-image reason: the
+    /// connection was intentionally severed, so there is nothing to repair
+    /// in place. Re-adding runs through Connect, a fresh authorization,
+    /// exactly as it would for a connection that never existed - which is
+    /// also why it carries no repair affordance and no Disconnect.
+    ///
+    /// `expired` and `needsReauth` stay Connected: both describe a
+    /// connection that did exist and can be repaired in place, and the badge
+    /// beside them is what tells the member what to fix.
     static func section(for ability: AbilitiesAPI.Ability) -> BrowserSection {
         switch ability.entitlementState {
         case .notEntitled:
@@ -170,9 +175,9 @@ final class AbilitiesListViewModel {
             return .statusUnknown
         case .entitled(let entitlement):
             switch entitlement.status {
-            case .pendingAuth:
+            case .pendingAuth, .revoked:
                 return .discover
-            case .active, .expired, .needsReauth, .revoked:
+            case .active, .expired, .needsReauth:
                 return .connected
             }
         }
@@ -253,9 +258,9 @@ final class AbilitiesListViewModel {
     }
 
     /// Starts the entitlement, or restarts it for every state that can
-    /// reach this method with one already on file (`pendingAuth` from a
-    /// Discover row, `expired` / `needsReauth` / `revoked` from a Connected
-    /// row's Reconnect).
+    /// reach this method with one already on file (`pendingAuth` / `revoked`
+    /// from a Discover row, `expired` / `needsReauth` from a Connected row's
+    /// Reconnect).
     ///
     /// A restart never re-serves the previous consent URL -- that link
     /// session has its own expiry, and re-opening it is what walks the

--- a/Convos/Abilities/AbilityDetailView.swift
+++ b/Convos/Abilities/AbilityDetailView.swift
@@ -11,13 +11,25 @@ import SwiftUI
 /// `AbilitiesListScreen`.
 struct AbilityDetailScreen: View {
     @State private var viewModel: AbilityDetailViewModel
+    /// App-wide actions, injected only by the App Settings entry point. Nil
+    /// from the in-convo browser, where disconnect stays out of reach (see
+    /// `AbilitiesListView.navigableEntitledRow` and the composerModal push).
+    private let onDisconnect: (() -> Void)?
+    private let onReconnect: (() -> Void)?
 
-    init(ability: AbilitiesAPI.Ability, usageSource: any ConnectionUsageSourcing) {
+    init(
+        ability: AbilitiesAPI.Ability,
+        usageSource: any ConnectionUsageSourcing,
+        onDisconnect: (() -> Void)? = nil,
+        onReconnect: (() -> Void)? = nil
+    ) {
         _viewModel = State(initialValue: AbilityDetailViewModel(ability: ability, usageSource: usageSource))
+        self.onDisconnect = onDisconnect
+        self.onReconnect = onReconnect
     }
 
     var body: some View {
-        AbilityDetailView(viewModel: viewModel)
+        AbilityDetailView(viewModel: viewModel, onDisconnect: onDisconnect, onReconnect: onReconnect)
     }
 }
 
@@ -44,10 +56,17 @@ struct AbilityDetailScreen: View {
 /// which reads as a card in light mode and as nothing at all in dark.
 struct AbilityDetailView: View {
     @Bindable var viewModel: AbilityDetailViewModel
+    /// App-wide disconnect/reconnect, injected only from App Settings. Nil
+    /// hides the action section, keeping the in-convo browser read-only.
+    var onDisconnect: (() -> Void)?
+    var onReconnect: (() -> Void)?
+    @Environment(\.dismiss) private var dismiss: DismissAction
+    @State private var showDisconnectConfirmation: Bool = false
 
     var body: some View {
         List {
             headerSection
+            actionSection
             agentsSection
             peopleSection
             conversationsSection
@@ -58,6 +77,17 @@ struct AbilityDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .overlay { loadingOverlay }
         .task { await viewModel.refresh() }
+        .confirmationDialog(
+            "Disconnect \(viewModel.ability.displayName.resolved())?",
+            isPresented: $showDisconnectConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Disconnect", role: .destructive) {
+                onDisconnect?()
+                dismiss()
+            }
+            Button("Cancel", role: .cancel) {}
+        }
         .accessibilityIdentifier("ability-detail-\(viewModel.ability.id)")
     }
 
@@ -77,17 +107,68 @@ struct AbilityDetailView: View {
                         .lineLimit(2)
                 }
                 Spacer()
-                if let entitlement = viewModel.ability.entitlement {
-                    AbilityStatusBadge(status: entitlement.status)
-                }
             }
-            // One element, read in the order it is laid out: as three
-            // separate texts the status landed between the name and the
-            // subtitle.
+            // Name and subtitle read as one element rather than two texts.
             .accessibilityElement(children: .combine)
         }
         .listRowBackground(Color.colorBackgroundRaised)
         .listSectionMargins(.top, DesignConstants.Spacing.step3x)
+        // Pull the action buttons up close under the card.
+        .listSectionSpacing(DesignConstants.Spacing.step2x)
+    }
+
+    /// App-wide actions, directly under the identity card. Present only when
+    /// the App Settings entry point injected `onDisconnect`; the in-convo
+    /// browser leaves it off. Reconnect leads only when the connection is
+    /// broken, where the removed list menu used to offer it.
+    @ViewBuilder
+    private var actionSection: some View {
+        if onDisconnect != nil {
+            Section {
+                VStack(spacing: DesignConstants.Spacing.step3x) {
+                    reconnectButton
+                    disconnectButton
+                }
+            }
+            .listRowBackground(Color.clear)
+            .listRowSeparator(.hidden)
+            // Zero the row insets so the full-width buttons span the same
+            // width as the cards, whose backgrounds fill the whole cell.
+            .listRowInsets(EdgeInsets())
+            .listSectionMargins(.top, 0)
+        }
+    }
+
+    @ViewBuilder
+    private var reconnectButton: some View {
+        if needsReconnect, let onReconnect {
+            let reconnectAction: () -> Void = {
+                onReconnect()
+                dismiss()
+            }
+            Button("Reconnect", action: reconnectAction)
+                .convosButtonStyle(.rounded(fullWidth: true))
+                .accessibilityIdentifier("ability-detail-reconnect")
+        }
+    }
+
+    private var disconnectButton: some View {
+        let disconnectAction: () -> Void = { showDisconnectConfirmation = true }
+        return Button("Disconnect", action: disconnectAction)
+            .buttonStyle(RoundedDestructiveButtonStyle(fullWidth: true))
+            .accessibilityIdentifier("ability-detail-disconnect")
+    }
+
+    /// The states that repair in place. `revoked` is routed to Discover
+    /// (see `AbilitiesListViewModel.section(for:)`), so it never reaches
+    /// this screen and offers no Reconnect.
+    private var needsReconnect: Bool {
+        switch viewModel.ability.entitlement?.status {
+        case .expired, .needsReauth:
+            true
+        default:
+            false
+        }
     }
 
     @ViewBuilder
@@ -143,11 +224,11 @@ struct AbilityDetailView: View {
     /// A read that reached no conversation cannot claim the connection is
     /// unused: it says what it knows, which is nothing.
     private var agentsEmptyTitle: String {
-        viewModel.isUnavailable ? Constant.unavailableTitle : "No agents are using this yet"
+        viewModel.isUnavailable ? Constant.unavailableTitle : "None"
     }
 
     private var conversationsEmptyTitle: String {
-        viewModel.isUnavailable ? Constant.unavailableTitle : "Not turned on in any convo yet"
+        viewModel.isUnavailable ? Constant.unavailableTitle : "None"
     }
 
     // MARK: - Rows
@@ -167,7 +248,7 @@ struct AbilityDetailView: View {
 
     private func emptyRow(_ title: String, identifier: String) -> some View {
         Text(title)
-            .font(.footnote)
+            .font(.body)
             .foregroundStyle(.colorTextSecondary)
             .accessibilityIdentifier(identifier)
     }
@@ -190,7 +271,12 @@ struct AbilityDetailView: View {
     let gcal = MockAbilitiesService.standardCatalog().first { $0.id == "googlecalendar" }
     if let gcal {
         NavigationStack {
-            AbilityDetailScreen(ability: gcal, usageSource: PreviewConnectionUsageSource())
+            AbilityDetailScreen(
+                ability: gcal,
+                usageSource: PreviewConnectionUsageSource(),
+                onDisconnect: {},
+                onReconnect: {}
+            )
         }
     }
 }

--- a/Convos/Abilities/AbilityDetailView.swift
+++ b/Convos/Abilities/AbilityDetailView.swift
@@ -123,7 +123,7 @@ struct AbilityDetailView: View {
     /// broken, where the removed list menu used to offer it.
     @ViewBuilder
     private var actionSection: some View {
-        if onDisconnect != nil {
+        if showsActions {
             Section {
                 VStack(spacing: DesignConstants.Spacing.step3x) {
                     reconnectButton
@@ -141,9 +141,9 @@ struct AbilityDetailView: View {
 
     @ViewBuilder
     private var reconnectButton: some View {
-        if needsReconnect, let onReconnect {
+        if showsReconnect {
             let reconnectAction: () -> Void = {
-                onReconnect()
+                onReconnect?()
                 dismiss()
             }
             Button("Reconnect", action: reconnectAction)
@@ -157,6 +157,18 @@ struct AbilityDetailView: View {
         return Button("Disconnect", action: disconnectAction)
             .buttonStyle(RoundedDestructiveButtonStyle(fullWidth: true))
             .accessibilityIdentifier("ability-detail-disconnect")
+    }
+
+    /// The section is App Settings only: the in-convo browser injects no
+    /// actions, so it stays read-only.
+    private var showsActions: Bool {
+        onDisconnect != nil
+    }
+
+    /// Reconnect leads only for a repairable connection the caller can
+    /// actually restart.
+    private var showsReconnect: Bool {
+        needsReconnect && onReconnect != nil
     }
 
     /// The states that repair in place. `revoked` is routed to Discover

--- a/ConvosTests/AbilitiesBrowserSectioningTests.swift
+++ b/ConvosTests/AbilitiesBrowserSectioningTests.swift
@@ -4,9 +4,9 @@ import XCTest
 
 /// The Connections browser's two-section split in `.composerModal`:
 /// Connected holds the entitlements whose authorization actually finished,
-/// Discover holds everything still connectable - not-entitled plus the
-/// `pendingAuth` records an abandoned OAuth leaves behind - and the outage
-/// section holds the rest.
+/// Discover holds everything still connectable - not-entitled, the
+/// `pendingAuth` records an abandoned OAuth leaves behind, and `revoked`
+/// ones a member severed - and the outage section holds the rest.
 @MainActor
 final class AbilitiesBrowserSectioningTests: XCTestCase {
     func testRepairableEntitlementsStayUnderConnected() async throws {
@@ -50,7 +50,7 @@ final class AbilitiesBrowserSectioningTests: XCTestCase {
             (.active, .connected),
             (.expired, .connected),
             (.needsReauth, .connected),
-            (.revoked, .connected),
+            (.revoked, .discover),
             (.pendingAuth, .discover),
         ]
         for (status, section) in expected {


### PR DESCRIPTION
## What & why

UI cleanup of the two Connections surfaces (internally "Abilities"), driven by design feedback on the list and detail screens.

### Connections list (App Settings)
- Removed the green **"Active"** status tag and the three-dot (`ellipsis`) menu from Connected rows — active rows now read clean and just push the detail via the chevron. Broken states (Expired/Reconnect) keep their badge as a warning.
- Renamed the **"All connections"** section to **"Add a connection"**, and made the **whole available row the Connect action** (removing the inline "Connect" button). Subtitles now have room to render in full.

### Connection detail
- Added a full-width **Disconnect** button directly under the identity card (8px gap), gated by a confirmation dialog. A state-aware **Reconnect** button appears above it for repairable states.
- Disconnect/Reconnect are injected **only from the App Settings entry point**, so the in-convo (composer) browser stays read-only — preserving the existing "Disconnect is app-wide only" invariant.
- Removed the "Active" tag from the header; empty **Agents/Convos** rows now read **"None"** at body size, matching the People row.

### Behavior change: `revoked` → Discover
Reclassified `revoked` entitlements from **Connected** to **Discover** (`AbilitiesListViewModel.section(for:)`). A severed connection has nothing to repair in place, so it re-adds through Connect like a never-connected app — and it no longer surfaces a confusing "Disconnect below Reconnect" pairing. Note: the backend doesn't emit `revoked` yet (it's reserved), so this is a forward-looking correctness fix with no visible change on current data. Updated the pinned section-mapping test accordingly.

## Testing
- Verified every screen and flow live in the simulator (screenshots throughout the change).
- `xcodebuild` build succeeds (Convos Dev); SwiftLint `--strict` clean on all changed files.
- App-target abilities tests pass, including the updated `AbilitiesBrowserSectioningTests`.

> Note: `ConversationViewModelDoneRevokeTests.testApproveAllTogglesOffDismissesSheetAndKeepsRequestPending` fails, but it **fails on the branch base without these changes too** — a pre-existing failure unrelated to this PR (the changes here don't touch that flow). ConvosCore is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rework Connections list and detail UI with full-row connect and detail actions
> - Available rows in App Settings become full-row Connect buttons with a busy spinner; Composer Modal keeps the inline Connect accessory unchanged
> - Connected rows lose the overflow menu; Reconnect and Disconnect actions move to [AbilityDetailView.swift](https://github.com/xmtplabs/convos-ios/pull/1450/files#diff-3de7ca19e42dc58e65df3c9b978572f93af1a4dbda95abfa88b6fb701a6ce9d2) as full-width buttons with a confirmation dialog before disconnect
> - Revoked entitlements now appear under Discover instead of Connected via `section(for:)` in [AbilitiesListViewModel.swift](https://github.com/xmtplabs/convos-ios/pull/1450/files#diff-10c0db3348ca8f1679580b316ca5d57a7525e4ea509e9ec42d3607c5344cc51a)
> - Header status badge removed from the detail screen; empty-state copy for agents and conversations shortened to "None"
> - Behavioral Change: `entitledMenu` is removed from [AbilitiesListView.swift](https://github.com/xmtplabs/convos-ios/pull/1450/files#diff-3cf3f424294144da687f79adab8ba19720705c566bd5647aef0ae14b79edf04f), so Reconnect/Disconnect are only reachable from the detail screen. `.revoked` moves from `.connected` to `.discover`; consumers relying on revoked abilities in the Connected section will see them shift sections.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0764d6b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->