### PR TITLE
feat(agent-model): the picker follows a switch made on another device

### DIFF
--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -51,6 +51,11 @@ struct ContactDetailView: View {
     /// the agent profile, mirroring the in-chat ribbon.
     let variantStamp: AgentVariantStamp?
     let mode: ContactDetailMode
+    /// The model this agent runs on as the conversation's synced state carries
+    /// it, passed from the live member row at the chat-side entry point (`nil`
+    /// elsewhere, and `nil` for an agent nobody has switched). A change here is
+    /// somebody else's pick arriving over sync, and the picker follows it.
+    let syncedAgentModel: String?
     /// True when the view should render its own X close button in the
     /// nav-bar's cancellation slot. Sheet entry points (where there is no
     /// system back button) keep this on; NavigationLink push entry points
@@ -122,6 +127,7 @@ struct ContactDetailView: View {
         contact: Contact,
         variantStamp: AgentVariantStamp? = nil,
         mode: ContactDetailMode = .standalone,
+        syncedAgentModel: String? = nil,
         contactsWriter: any ContactsWriterProtocol,
         contactsRepository: any ContactsRepositoryProtocol,
         session: (any SessionManagerProtocol)? = nil,
@@ -135,6 +141,7 @@ struct ContactDetailView: View {
         self.contact = contact
         self.variantStamp = variantStamp
         self.mode = mode
+        self.syncedAgentModel = syncedAgentModel
         self.contactsWriter = contactsWriter
         self.contactsRepository = contactsRepository
         self.session = session
@@ -390,6 +397,7 @@ struct ContactDetailView: View {
                     agentEmail: contact.agentEmail,
                     agentInstanceId: contact.agentInstanceId,
                     agentModelService: agentModelService,
+                    syncedAgentModel: syncedAgentModel,
                     // The displayed agent's own variant first: an agent built
                     // on a variant worker exists only there, so routing its
                     // switch by whatever the global selector happens to hold
@@ -937,6 +945,9 @@ private struct ContactDetailActions: View {
     /// name rather than the agent's. Nil outside a conversation, where there is
     /// no appData to write into and the Worker's own publish carries the switch.
     let agentModelService: (any AgentModelServing)?
+    /// What the room says this agent is on, followed by the picker so a switch
+    /// made on another device shows here too.
+    let syncedAgentModel: String?
     /// Dev-only variant routing key for the model picker. An agent built on a
     /// variant worker only exists there, so a switch that omits this lands on
     /// the default worker and changes nothing. Nil (and stripped in
@@ -977,7 +988,8 @@ private struct ContactDetailActions: View {
                     contactDisplayName: contactDisplayName,
                     instanceId: agentInstanceId,
                     variantId: agentVariantId,
-                    service: agentModelService
+                    service: agentModelService,
+                    syncedModel: syncedAgentModel
                 )
             }
             if showShare {
@@ -1125,6 +1137,10 @@ private struct ContactDetailModelRow: View {
     let contactDisplayName: String
     let instanceId: String
     let variantId: String?
+    /// The model the conversation's synced state names for this agent. Nil
+    /// where there is no synced state to read (the standalone card) and for an
+    /// agent nobody has switched.
+    let syncedModel: String?
 
     @State private var store: AgentModelStore
 
@@ -1132,11 +1148,13 @@ private struct ContactDetailModelRow: View {
         contactDisplayName: String,
         instanceId: String,
         variantId: String?,
-        service: (any AgentModelServing)?
+        service: (any AgentModelServing)?,
+        syncedModel: String? = nil
     ) {
         self.contactDisplayName = contactDisplayName
         self.instanceId = instanceId
         self.variantId = variantId
+        self.syncedModel = syncedModel
         _store = State(
             wrappedValue: service.map {
                 AgentModelStore(instanceId: instanceId, variantId: variantId, service: $0)
@@ -1158,7 +1176,17 @@ private struct ContactDetailModelRow: View {
                 .foregroundStyle(.colorTextSecondary)
                 .padding(.horizontal, DesignConstants.Spacing.step4x)
         }
+        // Seeded before the read so the row opens on what the room already
+        // says rather than "Default"; `load()` follows with the catalogue and
+        // the control plane's own answer.
+        .onAppear { applySyncedModelIfKnown() }
         .task { await store.load() }
+        // Someone else's pick arrives as a change to this conversation's synced
+        // member row. Nothing here polls, and a write of this device's own is
+        // newer than any sync, which the store already knows.
+        .onChange(of: syncedModel) { _, model in
+            store.apply(syncedModel: model)
+        }
         .alert(
             "Model unchanged",
             isPresented: Binding(
@@ -1170,6 +1198,14 @@ private struct ContactDetailModelRow: View {
         } message: {
             Text(store.errorMessage ?? "")
         }
+    }
+
+    /// Only when the card is scoped to a conversation. A nil outside one means
+    /// "nothing synced to read", not "no model", and adopting it would claim
+    /// the agent is on its default before the control plane has answered.
+    private func applySyncedModelIfKnown() {
+        guard syncedModel != nil else { return }
+        store.apply(syncedModel: syncedModel)
     }
 
     @ViewBuilder

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1909,6 +1909,14 @@ struct MemberContactDetailSheetContent: View {
     @Bindable var profileSettingsViewModel: ProfileSettingsViewModel
     var onStartAgentDm: ((String) -> Void)?
 
+    /// This member's model as the live conversation carries it, falling back to
+    /// the presented copy while the roster is still loading.
+    private var syncedAgentModel: String? {
+        viewModel.conversation.members
+            .first { $0.profile.inboxId == member.profile.inboxId }?
+            .agentModel ?? member.agentModel
+    }
+
     var body: some View {
         let messagingService = viewModel.messagingService
         let contactsRepository = messagingService.contactsRepository()
@@ -1933,6 +1941,12 @@ struct MemberContactDetailSheetContent: View {
                     invitedBy: member.invitedBy,
                     joinedAt: member.joinedAt
                 ),
+                // Read from the conversation the view model observes, not from
+                // the member captured when this sheet was presented: a switch
+                // another device makes lands as a change to that row, and the
+                // captured copy would hold the value from the moment of the tap
+                // forever.
+                syncedAgentModel: syncedAgentModel,
                 contactsWriter: contactsWriter,
                 contactsRepository: contactsRepository,
                 session: viewModel.session,

--- a/ConvosCore/Sources/ConvosComposer/AgentModelStore.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentModelStore.swift
@@ -222,6 +222,13 @@ public final class AgentModelStore {
     /// clobbered by the older server value the read was already fetching.
     private var writeGeneration: Int = 0
 
+    /// Bumped whenever a synced value is adopted. A `load()` started before it
+    /// is reading from before the room moved, so its answer is already stale
+    /// when it returns — without this, a switch someone else made while the
+    /// read was in flight is overwritten by the model the control plane held a
+    /// moment earlier, and the picker stays wrong until the next refresh.
+    private var syncGeneration: Int = 0
+
     /// Writes issued and not yet answered. A read overlapping one is reading
     /// from before it lands, so its value is already behind the member's tap
     /// even though no generation changed while it was in flight.
@@ -284,6 +291,7 @@ public final class AgentModelStore {
             return
         }
         deferredSyncedModel = nil
+        syncGeneration += 1
         confirmedId = syncedModel
         selectedId = syncedModel
     }
@@ -291,6 +299,7 @@ public final class AgentModelStore {
     /// Reads the agent's model and catalogue. Safe to call on every appearance.
     public func load() async {
         let generation = writeGeneration
+        let sync = syncGeneration
         let inFlight = writesInFlight
         do {
             let snapshot = try await service.readModel(
@@ -300,9 +309,12 @@ public final class AgentModelStore {
             // The catalogue is not a member's choice, so it applies regardless
             // of a tap that raced this read.
             if !snapshot.available.isEmpty { options = snapshot.available }
-            // A tap landed while this was in flight; its value is newer than
-            // anything this read can be carrying.
-            guard writeGeneration == generation, writesInFlight == inFlight else {
+            // A tap landed while this was in flight, or the room moved under
+            // it. Either is newer than anything this read can be carrying.
+            guard writeGeneration == generation,
+                  syncGeneration == sync,
+                  writesInFlight == inFlight
+            else {
                 hasLoaded = true
                 return
             }

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversationMemberProfileWithRole.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversationMemberProfileWithRole.swift
@@ -8,6 +8,9 @@ struct DBConversationMemberProfileWithRole: Codable, FetchableRecord, Hashable {
     let inboxId: String
     let role: MemberRole
     let createdAt: Date
+    /// Mirrored from the agent's profile in the group's appData. Nil for a
+    /// human member, and nil for a query that does not select the column.
+    let agentModel: String?
     let profile: DBProfile?
     let avatarSlot: DBProfileAvatarLatest?
     let inviterProfile: DBProfile?
@@ -57,7 +60,8 @@ extension DBConversationMemberProfileWithRole {
             isAgent: isAgent,
             agentVerification: agentVerification,
             invitedBy: invitedByProfile,
-            joinedAt: createdAt
+            joinedAt: createdAt,
+            agentModel: agentModel
         )
     }
 
@@ -74,6 +78,7 @@ extension DBConversationMemberProfileWithRole {
                 DBConversationMember.Columns.inboxId,
                 DBConversationMember.Columns.role,
                 DBConversationMember.Columns.createdAt,
+                DBConversationMember.Columns.agentModel,
             ])
             .including(optional: DBConversationMember.profile)
             .including(optional: DBConversationMember.avatarSlot)
@@ -97,6 +102,7 @@ extension DBConversationMemberProfileWithRole {
                 DBConversationMember.Columns.inboxId,
                 DBConversationMember.Columns.role,
                 DBConversationMember.Columns.createdAt,
+                DBConversationMember.Columns.agentModel,
             ])
             .including(optional: DBConversationMember.profile)
             .including(optional: DBConversationMember.avatarSlot)

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationMember.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationMember.swift
@@ -11,9 +11,14 @@ public struct ConversationMember: Codable, Hashable, Identifiable, Sendable {
     public let agentVerification: AgentVerification
     public let invitedBy: Profile?
     public let joinedAt: Date?
+    /// The model this member runs on, when the member is an agent, as the
+    /// group's appData carries it. Nil for a human, and nil for an agent
+    /// nobody has switched — that agent runs whatever its template shipped,
+    /// which no member's device can name.
+    public let agentModel: String?
 
     private enum CodingKeys: String, CodingKey {
-        case profile, role, isCurrentUser, isAgent, agentVerification, invitedBy, joinedAt
+        case profile, role, isCurrentUser, isAgent, agentVerification, invitedBy, joinedAt, agentModel
     }
 
     public init(
@@ -23,7 +28,8 @@ public struct ConversationMember: Codable, Hashable, Identifiable, Sendable {
         isAgent: Bool = false,
         agentVerification: AgentVerification = .unverified,
         invitedBy: Profile? = nil,
-        joinedAt: Date? = nil
+        joinedAt: Date? = nil,
+        agentModel: String? = nil
     ) {
         self.profile = profile
         self.role = role
@@ -32,6 +38,7 @@ public struct ConversationMember: Codable, Hashable, Identifiable, Sendable {
         self.agentVerification = agentVerification
         self.invitedBy = invitedBy
         self.joinedAt = joinedAt
+        self.agentModel = agentModel
     }
 
     public init(from decoder: Decoder) throws {
@@ -43,6 +50,7 @@ public struct ConversationMember: Codable, Hashable, Identifiable, Sendable {
         self.agentVerification = try container.decodeIfPresent(AgentVerification.self, forKey: .agentVerification) ?? .unverified
         self.invitedBy = try container.decodeIfPresent(Profile.self, forKey: .invitedBy)
         self.joinedAt = try container.decodeIfPresent(Date.self, forKey: .joinedAt)
+        self.agentModel = try container.decodeIfPresent(String.self, forKey: .agentModel)
     }
 
     public var isVerifiedConvosAgent: Bool {

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
@@ -731,6 +731,7 @@ extension QueryInterfaceRequest where RowDecoder == DBConversation {
                         DBConversationMember.Columns.inboxId,
                         DBConversationMember.Columns.role,
                         DBConversationMember.Columns.createdAt,
+                        DBConversationMember.Columns.agentModel,
                     ])
                     .including(optional: DBConversationMember.profile)
                     .including(optional: DBConversationMember.avatarSlot)

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -940,6 +940,7 @@ fileprivate extension Database {
                         DBConversationMember.Columns.inboxId,
                         DBConversationMember.Columns.role,
                         DBConversationMember.Columns.createdAt,
+                        DBConversationMember.Columns.agentModel,
                     ])
                     .including(optional: DBConversationMember.profile)
                     .including(optional: DBConversationMember.avatarSlot)

--- a/ConvosCore/Tests/ConvosCoreTests/AgentModelSyncTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentModelSyncTests.swift
@@ -17,6 +17,8 @@ import XMTPiOS
 struct AgentModelSyncTests {
     private static let agentInboxId = "aa".repeat(32)
     private static let otherAgentInboxId = "bb".repeat(32)
+    private static let currentInboxId = "cc".repeat(32)
+    private static let conversationId = "convo-agent-model"
 
     // MARK: - Migration
 
@@ -287,6 +289,112 @@ struct AgentModelSyncTests {
         )
 
         #expect(change.field != ConversationUpdate.MetadataChange.Field.agentModel.rawValue)
+    }
+
+    // MARK: - Reaching the surface that renders it
+
+    @Test("a stored model reaches the hydrated member the picker reads")
+    func storedModelReachesHydratedMember() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversationWithAgent(db: db, model: "anthropic/claude-sonnet-5")
+        }
+
+        let repo = ConversationsRepository(dbReader: dbManager.dbReader, consent: [.allowed])
+        let conversation = try repo.findOneToOne(with: Self.agentInboxId, excluding: nil)
+
+        let agent = conversation?.membersWithoutCurrent.first { $0.profile.inboxId == Self.agentInboxId }
+        #expect(agent?.agentModel == "anthropic/claude-sonnet-5")
+    }
+
+    @Test("a member nobody has switched hydrates with no model rather than a guessed one")
+    func unswitchedMemberHydratesWithoutAModel() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversationWithAgent(db: db, model: nil)
+        }
+
+        let repo = ConversationsRepository(dbReader: dbManager.dbReader, consent: [.allowed])
+        let conversation = try repo.findOneToOne(with: Self.agentInboxId, excluding: nil)
+
+        let agent = conversation?.membersWithoutCurrent.first { $0.profile.inboxId == Self.agentInboxId }
+        #expect(agent != nil)
+        #expect(agent?.agentModel == nil)
+    }
+
+    /// A 1:1 between the current user and the agent, carrying every row the
+    /// detailed conversation query joins as required.
+    private static func seedConversationWithAgent(db: Database, model: String?) throws {
+        let now = Date()
+        try DBMember(inboxId: currentInboxId).save(db, onConflict: .ignore)
+        try DBInbox(inboxId: currentInboxId, clientId: "client-current", createdAt: now)
+            .save(db, onConflict: .ignore)
+        try DBMember(inboxId: agentInboxId).save(db, onConflict: .ignore)
+
+        try DBConversation(
+            id: conversationId,
+            clientConversationId: "client-\(conversationId)",
+            inviteTag: "tag-\(conversationId)",
+            creatorId: currentInboxId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: now,
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: true
+        ).insert(db)
+
+        try ConversationLocalState(
+            conversationId: conversationId,
+            isPinned: false,
+            isUnread: false,
+            isUnreadUpdatedAt: now,
+            isMuted: false,
+            pinnedOrder: nil,
+            hidesInviteCard: false,
+            leftHostedInviteSession: false,
+            wasRemoved: false,
+            hasHadOtherMembers: true,
+            hasSharedInvite: false
+        ).insert(db)
+
+        try seedMember(db: db, inboxId: currentInboxId, role: .superAdmin, model: nil)
+        try seedMember(db: db, inboxId: agentInboxId, role: .member, model: model)
+    }
+
+    private static func seedMember(
+        db: Database,
+        inboxId: String,
+        role: MemberRole,
+        model: String?
+    ) throws {
+        try DBConversationMember(
+            conversationId: conversationId,
+            inboxId: inboxId,
+            role: role,
+            consent: .allowed,
+            createdAt: Date(),
+            invitedByInboxId: nil,
+            agentModel: model
+        ).insert(db)
+        try DBMemberProfile(
+            conversationId: conversationId,
+            inboxId: inboxId,
+            name: inboxId,
+            avatar: nil
+        ).insert(db, onConflict: .ignore)
     }
 }
 

--- a/ConvosTests/AgentModelStoreSyncRaceTests.swift
+++ b/ConvosTests/AgentModelStoreSyncRaceTests.swift
@@ -1,0 +1,108 @@
+import ConvosComposer
+import XCTest
+@testable import Convos
+
+/// A model service a test can hold still: the read parks on a continuation
+/// until the test releases it, so a synced value can be delivered while the
+/// read is provably in flight rather than hoping a sleep lands in the gap.
+private actor ScriptedModelService: AgentModelServing {
+    private var serverModel: String?
+    private let catalogue: [AgentModelOption]
+    private var pendingReads: [CheckedContinuation<Void, Never>] = []
+    private var holdsReads: Bool = false
+
+    init(serverModel: String?, catalogue: [AgentModelOption]) {
+        self.serverModel = serverModel
+        self.catalogue = catalogue
+    }
+
+    func holdReads(_ holds: Bool) {
+        holdsReads = holds
+    }
+
+    func releaseReads() {
+        let waiting = pendingReads
+        pendingReads = []
+        waiting.forEach { $0.resume() }
+    }
+
+    func waitForPendingRead() async {
+        while pendingReads.isEmpty {
+            await Task.yield()
+        }
+    }
+
+    func readModel(instanceId: String, variantId: String?) async throws -> AgentModelSnapshot {
+        if holdsReads {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                pendingReads.append(continuation)
+            }
+        }
+        return AgentModelSnapshot(model: serverModel, available: catalogue)
+    }
+
+    func writeModel(
+        _ model: String,
+        instanceId: String,
+        variantId: String?
+    ) async throws -> AgentModelSnapshot {
+        serverModel = model
+        return AgentModelSnapshot(model: model, available: catalogue)
+    }
+}
+
+@MainActor
+final class AgentModelStoreSyncRaceTests: XCTestCase {
+    private let catalogue = [
+        AgentModelOption(id: "anthropic/claude-sonnet-5", name: "Claude Sonnet 5"),
+        AgentModelOption(id: "openai/gpt-5.6-sol", name: "GPT-5.6 Sol"),
+    ]
+
+    /// Someone else's switch arriving mid-read owns the picker. The read was
+    /// already fetching the model the control plane held before the switch, so
+    /// letting its answer land would put the picker back on the old model and
+    /// leave it there until something else refreshed it.
+    func testSyncedModelDuringReadSurvivesTheRead() async {
+        let service = ScriptedModelService(
+            serverModel: "anthropic/claude-sonnet-5",
+            catalogue: catalogue
+        )
+        await service.holdReads(true)
+        let store = AgentModelStore(
+            instanceId: "instance-1",
+            service: service
+        )
+
+        let load = Task { await store.load() }
+        await service.waitForPendingRead()
+        store.apply(syncedModel: "openai/gpt-5.6-sol")
+        await service.releaseReads()
+        await load.value
+
+        XCTAssertEqual(store.selectedId, "openai/gpt-5.6-sol")
+        // The catalogue is not a member's choice, so the read still delivers it.
+        XCTAssertEqual(store.options.map(\.id), catalogue.map(\.id))
+    }
+
+    /// The room clearing a model is a value like any other: a read that was
+    /// already fetching the old one must not put it back.
+    func testSyncedClearDuringReadSurvivesTheRead() async {
+        let service = ScriptedModelService(
+            serverModel: "anthropic/claude-sonnet-5",
+            catalogue: catalogue
+        )
+        await service.holdReads(true)
+        let store = AgentModelStore(
+            instanceId: "instance-1",
+            service: service
+        )
+
+        let load = Task { await store.load() }
+        await service.waitForPendingRead()
+        store.apply(syncedModel: nil)
+        await service.releaseReads()
+        await load.value
+
+        XCTAssertNil(store.selectedId)
+    }
+}


### PR DESCRIPTION
A model change already reaches every member — it rides the group's appData, and each device draws the transcript row ("X switched the agent to Claude Sonnet 5") from it. What never travelled was the value the **picker** shows. `AgentModelStore.apply(syncedModel:)` was written and tested for exactly this and had no caller, and `conversation_members.agentModel` — the column the sync lands in — was read by nothing. So a member opening the agent's card after someone else switched it saw "Default", or their own last pick, with nothing to correct it.

This is the missing wire, and only that.

- `ConversationMember` carries `agentModel`, hydrated through the one funnel every member goes through (`hydrateConversationMember`), with the column selected in the two queries that build a conversation's roster.
- The member sheet reads it off the conversation the view model observes, not the member captured when the sheet was presented — so a change that lands while the card is open moves the picker.
- The row seeds the store on appear and applies every later change. A nil outside a conversation means "nothing synced to read", not "no model", and is not adopted: the control plane's own answer stays the authority there.

Nothing about the write path, the catalogue, or the control plane moves.

Two tests cover the new reach, through the real roster query rather than the hydration helper alone: a stored model arrives on the hydrated member, and a member nobody switched hydrates with no model rather than a guessed one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790393918&installation_model_id=20076&pr_number=1451&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1451&signature=9bdc68d1428aa60f86ec1982c02c7637610549e72e810af2407a3061285efc3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make agent model picker follow remote switches from other devices
> - Passes the live conversation member's `agentModel` into `ContactDetailModelRow` so the picker initializes from and live-updates to the synced value instead of defaulting to "Default" before the catalogue read completes.
> - Adds `syncGeneration` to `AgentModelStore` so a synced model applied mid-read is not overwritten by the stale server value when the read finishes.
> - Extends `ConversationMember` with an optional `agentModel` field and includes it in detailed and lightweight conversation queries via `DBConversationMemberProfileWithRole`.
> - Adds tests for the read/sync race in `AgentModelStoreSyncRaceTests` and for member hydration in `AgentModelSyncTests`.
> - Behavioral Change: `ContactDetailModelRow.applySyncedModelIfKnown()` ignores `nil` synced models outside conversation scope; reviewers should check that this guard matches expected picker behavior when no conversation context is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 744c463.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->