### PR TITLE
Announce per-chat ability opt-ins to the agent's grant ledger

### DIFF
--- a/Convos/Abilities/AbilitiesServices.swift
+++ b/Convos/Abilities/AbilitiesServices.swift
@@ -13,13 +13,22 @@ struct AbilitiesSelection {
     /// Nil in mock mode: the stub authorization sheet stands in, and a
     /// mock connect never opens a real browser.
     let authorizer: (any AbilityAuthorizing)?
+    /// Announces landed per-chat opt-ins to the agent runtime's grant
+    /// ledger (profile metadata + backend consent record + transcript
+    /// event), so a toggled-on ability is usable without the agent
+    /// carding for consent the member already gave. Nil in mock mode and
+    /// before `configure`; a nil announcer keeps the backend-only
+    /// behavior (the agent cards once).
+    let announcer: (any AbilityGrantAnnouncing)?
 
     init(
         service: any AbilitiesServiceProtocol,
-        authorizer: (any AbilityAuthorizing)? = nil
+        authorizer: (any AbilityAuthorizing)? = nil,
+        announcer: (any AbilityGrantAnnouncing)? = nil
     ) {
         self.service = service
         self.authorizer = authorizer
+        self.announcer = announcer
     }
 }
 
@@ -41,6 +50,7 @@ enum AbilitiesServices {
     /// closure rather than a retained repository so the read happens off the
     /// main actor at the moment the detail screen asks for it.
     nonisolated(unsafe) private static var conversationsProvider: (@Sendable () async throws -> [Conversation])?
+    nonisolated(unsafe) private static var liveGrantAnnouncer: (any AbilityGrantAnnouncing)?
     private static let mockService: MockAbilitiesService = MockAbilitiesService()
 
     /// The atomic (service, authorizer) pair for the current mode. Resolve
@@ -53,7 +63,8 @@ enum AbilitiesServices {
         }
         return AbilitiesSelection(
             service: liveService,
-            authorizer: AbilityOAuthAuthorizer(callbackURLScheme: ConfigManager.shared.appUrlScheme)
+            authorizer: AbilityOAuthAuthorizer(callbackURLScheme: ConfigManager.shared.appUrlScheme),
+            announcer: liveGrantAnnouncer
         )
     }
 
@@ -89,6 +100,19 @@ enum AbilitiesServices {
             myInboxIdProvider: {
                 try? await messaging.sessionStateManager.waitForInboxReadyResult().client.inboxId
             }
+        )
+        // Successor to the deleted v1 awareness shim (#1442), production-on
+        // by design: landed toggles route through the same grant writer the
+        // capability-card path uses, so the agent stops carding for consent
+        // already given. See `CloudAbilityGrantAnnouncer`.
+        let connectionManager = session.cloudConnectionManager(
+            callbackURLScheme: ConfigManager.shared.appUrlScheme
+        )
+        liveGrantAnnouncer = CloudAbilityGrantAnnouncer(
+            repository: session.cloudConnectionRepository(),
+            grantWriter: { messaging.connectionGrantWriter() },
+            eventWriter: { messaging.connectionEventWriter() },
+            refreshConnections: { _ = try await connectionManager.refreshConnections() }
         )
     }
 

--- a/Convos/Abilities/ConnectionsBrowserMode.swift
+++ b/Convos/Abilities/ConnectionsBrowserMode.swift
@@ -15,9 +15,13 @@ import Foundation
 ///   row presents the screen full-screen from
 ///   `ConversationView`. The screen wraps itself in its own
 ///   `NavigationStack` with a Done dismiss control; ability detail pushes
-///   run inside that stack. Carries the launching DM's context: the
-///   Connected section scopes its per-chat toggles to that conversation
-///   and agent.
+///   run inside that stack. Carries the launching agent's context, and
+///   the DM's ORIGIN GROUP conversation id — never the DM's own: the
+///   backend authorizes the agent's tool calls against its primary group,
+///   so grant-side writes scoped to the DM's id authorize nothing (the
+///   same rule `CapabilityGrantScope` enforces for capability-card
+///   approvals). The Connected section scopes its per-chat toggles to
+///   that origin group and agent.
 ///
 /// Both modes render the same sections from the same view model; only the
 /// wrapper differs.

--- a/Convos/Abilities/ConversationAbilitiesViewModel.swift
+++ b/Convos/Abilities/ConversationAbilitiesViewModel.swift
@@ -666,6 +666,16 @@ final class ConversationAbilitiesViewModel {
                 // the visual settle on it would strand a real enablement
                 // on a spinner.
                 clearPendingEnablement(key)
+                // The write above already ran under the epoch guard, so the
+                // announcement needs no fence of its own. Best-effort inside
+                // the announcer: a failed announcement never reverts the
+                // toggle, the agent just cards once.
+                await selection.announcer?.announceEnabled(
+                    conversationId: conversationId,
+                    agentInboxId: agent.inboxId,
+                    abilityId: ability.id,
+                    bundleIds: bundleIds
+                )
             } catch AbilitiesServiceError.needsEntitlement {
                 // The server says the entitlement is gone mid-extend: run
                 // the repair flow and retry with the bundles the user
@@ -728,6 +738,14 @@ final class ConversationAbilitiesViewModel {
                     conversationId: conversationId,
                     abilityId: ability.id,
                     agentInboxId: agent.inboxId
+                )
+                // Mirrors the extend-side announcement, including through
+                // the service's benign not-found path — a stale announced
+                // grant must not outlive a withdrawal.
+                await selection.announcer?.announceDisabled(
+                    conversationId: conversationId,
+                    agentInboxId: agent.inboxId,
+                    abilityId: ability.id
                 )
             } catch {
                 mutationError = error.localizedDescription

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1701,18 +1701,22 @@ private extension ConversationView {
     }
 
     /// Powerplug tap from the `+` menu row: presents the Connections
-    /// browser full-screen, carrying the launching DM's conversation,
-    /// agent inbox id and agent name so its Connected section can scope
-    /// its toggles. Guarded by the same capability that offered the row.
+    /// browser full-screen, carrying the agent inbox id and agent name so
+    /// its Connected section can scope its toggles — and the ORIGIN GROUP's
+    /// conversation id, never the DM's own. The backend authorizes the
+    /// agent's tool calls against its primary group, so grant-side writes
+    /// scoped to the DM's id authorize nothing — the same rule
+    /// `CapabilityGrantScope` enforces for capability-card approvals.
+    /// `viewModel` here is the hosting group the agent lane rides in.
+    /// Guarded by the same capability that offered the row.
     func handleComposerConnectionsTap() {
         guard composerConnectionsEnabled,
               let agentDmSession,
-              let agentInboxId = agentDmSession.agentInboxId,
-              let dmConversationId = agentDmSession.dmViewModel?.conversation.id else {
+              let agentInboxId = agentDmSession.agentInboxId else {
             return
         }
         connectionsBrowserContext = .composerModal(
-            conversationId: dmConversationId,
+            conversationId: viewModel.conversation.id,
             agentInboxId: agentInboxId,
             agentDisplayName: agentDmSession.agentName
         )

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/AbilityGrantAnnouncer.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/AbilityGrantAnnouncer.swift
@@ -1,0 +1,214 @@
+import Foundation
+
+/// Announces a per-conversation ability opt-in to the agent runtime.
+///
+/// The abilities surfaces (the Connections browser's per-chat toggles and
+/// the conversation-info section) write the backend entitlement tables, but
+/// the agent runtime's connections skill resolves grants from the sender's
+/// profile metadata (`metadata["connections"]`) - the ledger only the
+/// capability-card approval path wrote. Without this announcement a
+/// toggled-on ability is authorized backend-side yet invisible to the
+/// agent, which then cards the member for consent they already gave.
+///
+/// Successor to the deleted `AbilityV1AwarenessShimWriter` (removed in
+/// #1442 as dead debug code), with different semantics: production-on by
+/// design, and full card-path equivalence - real grant rows via
+/// `CloudConnectionGrantWriter` (metadata payload + backend consent
+/// record) plus the in-chat granted/revoked `ConnectionEvent` - rather
+/// than the shim's flag-gated raw-JSON side-write.
+///
+/// Best-effort by contract: the backend opt-in the caller just wrote is
+/// the authoritative record, so a failed announcement is logged and
+/// swallowed - the member's toggle must never revert because a profile
+/// publish failed. The worst case is the pre-announcement behavior: the
+/// agent asks once.
+public protocol AbilityGrantAnnouncing: Sendable {
+    /// The member enabled `abilityId` for `agentInboxId` in `conversationId`.
+    func announceEnabled(
+        conversationId: String,
+        agentInboxId: String,
+        abilityId: String,
+        bundleIds: [String]
+    ) async
+
+    /// The member disabled `abilityId` for `agentInboxId` in `conversationId`.
+    func announceDisabled(
+        conversationId: String,
+        agentInboxId: String,
+        abilityId: String
+    ) async
+}
+
+/// `AbilityGrantAnnouncing` backed by the same `CloudConnectionGrantWriter`
+/// the capability-card approval path uses, so a toggle-on becomes
+/// equivalent to approving a card.
+///
+/// Ability ids are Composio toolkit slugs, the same namespace as
+/// `CloudConnection.serviceId` (an assumption the deleted shim relied on
+/// undocumented; documented here), so resolution is a direct
+/// most-recent-active match over the repository's connections - with one
+/// `refreshConnections` retry, because an ability connected moments ago
+/// through the V2 abilities OAuth exists in the backend's list but not
+/// yet in the local store. The refresh is safe to call here: it is a
+/// delta update by design (see `CloudConnectionManager.refreshConnections`),
+/// never a delete-and-reinsert that would cascade grants away.
+///
+/// Idempotent by repository check, mirroring
+/// `AgentBuilderConnectionGrantReplayer`: an already-recorded grant for
+/// (service, agent, conversation) announces nothing - no duplicate backend
+/// push, no duplicate transcript line.
+public final class CloudAbilityGrantAnnouncer: AbilityGrantAnnouncing {
+    private let repository: any CloudConnectionRepositoryProtocol
+    private let grantWriter: @Sendable () -> any CloudConnectionGrantWriterProtocol
+    private let eventWriter: @Sendable () -> any ConnectionEventWriterProtocol
+    private let refreshConnections: @Sendable () async throws -> Void
+
+    public init(
+        repository: any CloudConnectionRepositoryProtocol,
+        grantWriter: @escaping @Sendable () -> any CloudConnectionGrantWriterProtocol,
+        eventWriter: @escaping @Sendable () -> any ConnectionEventWriterProtocol,
+        refreshConnections: @escaping @Sendable () async throws -> Void
+    ) {
+        self.repository = repository
+        self.grantWriter = grantWriter
+        self.eventWriter = eventWriter
+        self.refreshConnections = refreshConnections
+    }
+
+    public func announceEnabled(
+        conversationId: String,
+        agentInboxId: String,
+        abilityId: String,
+        bundleIds: [String]
+    ) async {
+        do {
+            let alreadyRecorded = try await repository.grants(for: conversationId).contains {
+                $0.serviceId == abilityId && $0.grantedToInboxId == agentInboxId
+            }
+            guard !alreadyRecorded else { return }
+
+            guard let connection = try await resolveActiveConnection(serviceId: abilityId) else {
+                Log.warning(
+                    "[abilities] no active cloud connection for \(abilityId) even after refresh; " +
+                        "grant not announced - the agent will card on first use"
+                )
+                return
+            }
+            // An empty explicit selection is never pushed (the writer fails
+            // closed on it); nil means full-service consent materialized
+            // from the catalog, which matches a toggle with no picker.
+            try await grantWriter().grantConnection(
+                connection.id,
+                to: conversationId,
+                grantedToInboxId: agentInboxId,
+                bundleIds: bundleIds.isEmpty ? nil : bundleIds
+            )
+            await broadcast(.granted, abilityId: abilityId, agentInboxId: agentInboxId, in: conversationId)
+        } catch is CancellationError {
+            return
+        } catch {
+            Log.warning(
+                "[abilities] announcing \(abilityId) enable failed " +
+                    "(conversationId=\(conversationId), agent=\(agentInboxId)): \(error); " +
+                    "the agent will card on first use"
+            )
+        }
+    }
+
+    public func announceDisabled(
+        conversationId: String,
+        agentInboxId: String,
+        abilityId: String
+    ) async {
+        do {
+            // Revoke by the recorded grant rows rather than the currently
+            // active connection: the connection that was granted may since
+            // have been replaced, and an un-announced grant (toggled on
+            // before announcements existed) simply has no rows to revoke.
+            let recorded = try await repository.grants(for: conversationId).filter {
+                $0.serviceId == abilityId && $0.grantedToInboxId == agentInboxId
+            }
+            for grant in recorded {
+                try await grantWriter().revokeGrant(
+                    connectionId: grant.connectionId,
+                    from: conversationId,
+                    grantedToInboxId: agentInboxId
+                )
+            }
+            // Only when something actually changed: a revoked-nothing
+            // broadcast would put a "removed" line in the transcript over
+            // a no-op.
+            if !recorded.isEmpty {
+                await broadcast(.revoked, abilityId: abilityId, agentInboxId: agentInboxId, in: conversationId)
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            Log.warning(
+                "[abilities] announcing \(abilityId) disable failed " +
+                    "(conversationId=\(conversationId), agent=\(agentInboxId)): \(error); " +
+                    "the metadata grant may outlive the withdrawn opt-in"
+            )
+        }
+    }
+
+    private enum BroadcastAction {
+        case granted
+        case revoked
+    }
+
+    /// The in-chat "connected their <service>" transcript line, exactly as
+    /// the capability-card path broadcasts it. Best-effort on its own: the
+    /// grant already landed, and a dropped transcript line is cosmetic
+    /// (same posture as `AgentBuilderConnectionGrantReplayer`).
+    private func broadcast(
+        _ action: BroadcastAction,
+        abilityId: String,
+        agentInboxId: String,
+        in conversationId: String
+    ) async {
+        let providerId = "composio.\(abilityId)"
+        do {
+            switch action {
+            case .granted:
+                try await eventWriter().sendGranted(
+                    providerId: providerId,
+                    capability: nil,
+                    grantedToInboxId: agentInboxId,
+                    in: conversationId
+                )
+            case .revoked:
+                try await eventWriter().sendRevoked(
+                    providerId: providerId,
+                    capability: nil,
+                    grantedToInboxId: agentInboxId,
+                    in: conversationId
+                )
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            Log.warning("[abilities] \(action) broadcast failed for \(abilityId) in \(conversationId): \(error)")
+        }
+    }
+
+    private func resolveActiveConnection(serviceId: String) async throws -> CloudConnection? {
+        if let connection = try await activeConnection(serviceId: serviceId) {
+            return connection
+        }
+        do {
+            try await refreshConnections()
+        } catch {
+            Log.warning("[abilities] connection refresh failed while resolving \(serviceId): \(error)")
+        }
+        return try await activeConnection(serviceId: serviceId)
+    }
+
+    /// Most-recent active connection for the service, matching
+    /// `CloudConnectionManager.existingActiveConnection`.
+    private func activeConnection(serviceId: String) async throws -> CloudConnection? {
+        try await repository.connections()
+            .filter { $0.serviceId == serviceId && $0.status == .active }
+            .max { $0.connectedAt < $1.connectedAt }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/AbilityGrantAnnouncer.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/AbilityGrantAnnouncer.swift
@@ -54,9 +54,20 @@ public protocol AbilityGrantAnnouncing: Sendable {
 /// never a delete-and-reinsert that would cascade grants away.
 ///
 /// Idempotent by repository check, mirroring
-/// `AgentBuilderConnectionGrantReplayer`: an already-recorded grant for
-/// (service, agent, conversation) announces nothing - no duplicate backend
-/// push, no duplicate transcript line.
+/// `AgentBuilderConnectionGrantReplayer` - but scope-aware: an
+/// already-recorded grant for (service, agent, conversation) whose bundle
+/// set matches the request announces nothing (no duplicate backend push,
+/// no duplicate transcript line), while a recorded grant with a
+/// *different* bundle set is re-granted so the corrected scope reaches
+/// the metadata payload and the backend consent record - the legacy
+/// entitlement fallback authorizes from that record, so a stale wider
+/// scope there would outlive the member's narrower re-selection. A scope
+/// correction is not a new connection, so it broadcasts no transcript
+/// event (matching the card path's diff-based
+/// `newlyApprovedProviderIds` broadcasting). A recorded nil bundle set
+/// (legacy full-service) compared against an explicit selection is
+/// treated as different - the conservative direction is to re-push the
+/// explicit scope.
 public final class CloudAbilityGrantAnnouncer: AbilityGrantAnnouncing {
     private let repository: any CloudConnectionRepositoryProtocol
     private let grantWriter: @Sendable () -> any CloudConnectionGrantWriterProtocol
@@ -82,10 +93,16 @@ public final class CloudAbilityGrantAnnouncer: AbilityGrantAnnouncing {
         bundleIds: [String]
     ) async {
         do {
-            let alreadyRecorded = try await repository.grants(for: conversationId).contains {
+            // An empty explicit selection is never pushed (the writer fails
+            // closed on it); nil means full-service consent materialized
+            // from the catalog, which matches a toggle with no picker.
+            let requestedBundles: [String]? = bundleIds.isEmpty ? nil : bundleIds
+            let recorded = try await repository.grants(for: conversationId).first {
                 $0.serviceId == abilityId && $0.grantedToInboxId == agentInboxId
             }
-            guard !alreadyRecorded else { return }
+            if let recorded, Self.scopeMatches(recorded: recorded.bundleIds, requested: requestedBundles) {
+                return
+            }
 
             guard let connection = try await resolveActiveConnection(serviceId: abilityId) else {
                 Log.warning(
@@ -94,16 +111,18 @@ public final class CloudAbilityGrantAnnouncer: AbilityGrantAnnouncing {
                 )
                 return
             }
-            // An empty explicit selection is never pushed (the writer fails
-            // closed on it); nil means full-service consent materialized
-            // from the catalog, which matches a toggle with no picker.
             try await grantWriter().grantConnection(
                 connection.id,
                 to: conversationId,
                 grantedToInboxId: agentInboxId,
-                bundleIds: bundleIds.isEmpty ? nil : bundleIds
+                bundleIds: requestedBundles
             )
-            await broadcast(.granted, abilityId: abilityId, agentInboxId: agentInboxId, in: conversationId)
+            // Only a NEW grant puts a "connected" line in the transcript; a
+            // scope correction over an existing grant is not a new
+            // connection (see the class doc).
+            if recorded == nil {
+                await broadcast(.granted, abilityId: abilityId, agentInboxId: agentInboxId, in: conversationId)
+            }
         } catch is CancellationError {
             return
         } catch {
@@ -189,6 +208,22 @@ public final class CloudAbilityGrantAnnouncer: AbilityGrantAnnouncing {
             return
         } catch {
             Log.warning("[abilities] \(action) broadcast failed for \(abilityId) in \(conversationId): \(error)")
+        }
+    }
+
+    /// Whether the recorded grant's bundle scope already covers exactly
+    /// what the caller is announcing. Nil on both sides is full-service
+    /// consent twice - a match. Nil on one side only cannot be compared
+    /// locally (the writer materializes nil from the live catalog), so it
+    /// reads as different and the explicit scope is re-pushed.
+    private static func scopeMatches(recorded: [String]?, requested: [String]?) -> Bool {
+        switch (recorded, requested) {
+        case (nil, nil):
+            return true
+        case let (recorded?, requested?):
+            return Set(recorded) == Set(requested)
+        default:
+            return false
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
@@ -576,8 +576,11 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
         let iso8601 = ISO8601DateFormatter()
         let entries: [CloudConnectionGrantEntry] = desiredGrants.compactMap { grant in
             guard let conn = connectionsById[grant.connectionId] else { return nil }
+            // Both built from the grant's OWN conversation id, not the
+            // ambient one: with the per-conversation projection they are
+            // always equal, but the entry describes the grant.
             return CloudConnectionGrantEntry(
-                id: "grant_\(grant.connectionId)_\(conversationId)_\(grant.grantedToInboxId)",
+                id: "grant_\(grant.connectionId)_\(grant.conversationId)_\(grant.grantedToInboxId)",
                 senderId: senderId,
                 grantedToInboxId: grant.grantedToInboxId,
                 service: conn.serviceId,
@@ -585,7 +588,8 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
                 scope: "conversation",
                 composioEntityId: conn.composioEntityId,
                 composioConnectionId: conn.composioConnectionId,
-                grantedAt: iso8601.string(from: grant.grantedAt)
+                grantedAt: iso8601.string(from: grant.grantedAt),
+                conversationId: grant.conversationId
             )
         }
 

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionsMetadataPayload.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionsMetadataPayload.swift
@@ -20,6 +20,14 @@ public struct CloudConnectionGrantEntry: Codable, Sendable, Hashable {
     public let composioEntityId: String
     public let composioConnectionId: String
     public let grantedAt: String              // ISO8601
+    /// Which conversation the grant scopes to. Additive (2026-08), for
+    /// wire-contract parity with Android: the runtime matches grants
+    /// without a conversation filter today, and this field is what lets
+    /// it grow one in a single server deploy covering both platforms.
+    /// Optional because entries written by older clients don't carry it;
+    /// readers must treat absence as "conversation unknown", never as
+    /// "applies everywhere".
+    public let conversationId: String?
 
     public init(
         id: String,
@@ -30,7 +38,8 @@ public struct CloudConnectionGrantEntry: Codable, Sendable, Hashable {
         scope: String = "conversation",
         composioEntityId: String,
         composioConnectionId: String,
-        grantedAt: String
+        grantedAt: String,
+        conversationId: String? = nil
     ) {
         self.id = id
         self.senderId = senderId
@@ -41,6 +50,7 @@ public struct CloudConnectionGrantEntry: Codable, Sendable, Hashable {
         self.composioEntityId = composioEntityId
         self.composioConnectionId = composioConnectionId
         self.grantedAt = grantedAt
+        self.conversationId = conversationId
     }
 }
 

--- a/ConvosCore/Tests/ConvosCoreTests/AbilityGrantAnnouncerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AbilityGrantAnnouncerTests.swift
@@ -28,13 +28,17 @@ struct AbilityGrantAnnouncerTests {
         )
     }
 
-    private static func recordedGrant(connectionId: String = "conn-a") -> CloudConnectionGrant {
+    private static func recordedGrant(
+        connectionId: String = "conn-a",
+        bundleIds: [String]? = nil
+    ) -> CloudConnectionGrant {
         CloudConnectionGrant(
             connectionId: connectionId,
             conversationId: conversationId,
             serviceId: "googlecalendar",
             grantedToInboxId: agentInboxId,
-            grantedAt: Date(timeIntervalSince1970: 0)
+            grantedAt: Date(timeIntervalSince1970: 0),
+            bundleIds: bundleIds
         )
     }
 
@@ -135,15 +139,58 @@ struct AbilityGrantAnnouncerTests {
         #expect(events.isEmpty, "no transcript line for a grant that never landed")
     }
 
-    @Test("An already-recorded grant announces nothing")
-    func alreadyRecordedIsIdempotent() async throws {
+    @Test("An already-recorded grant with the same scope announces nothing")
+    func sameScopeIsIdempotent() async throws {
         // Mirrors AgentBuilderConnectionGrantReplayer's repository-based
         // idempotency: no duplicate backend push, no duplicate transcript
-        // line for a grant the card path (or an earlier toggle) already
-        // announced.
+        // line for a scope the card path (or an earlier toggle) already
+        // announced. Order-insensitive: the same set is the same scope.
         let env = Self.makeEnv()
         await env.repository.setConnections([Self.connection()])
-        await env.repository.setGrants([Self.recordedGrant()])
+        await env.repository.setGrants(
+            [Self.recordedGrant(bundleIds: ["calendar.freebusy", "calendar.events"])]
+        )
+
+        await env.announcer.announceEnabled(
+            conversationId: Self.conversationId,
+            agentInboxId: Self.agentInboxId,
+            abilityId: "googlecalendar",
+            bundleIds: ["calendar.events", "calendar.freebusy"]
+        )
+
+        let grants = await env.grantWriter.grantedCalls()
+        #expect(grants.isEmpty)
+        let events = await env.eventWriter.grantedEvents()
+        #expect(events.isEmpty)
+    }
+
+    @Test("Full-service consent over a recorded full-service grant announces nothing")
+    func fullServiceOverFullServiceIsIdempotent() async throws {
+        let env = Self.makeEnv()
+        await env.repository.setConnections([Self.connection()])
+        await env.repository.setGrants([Self.recordedGrant(bundleIds: nil)])
+
+        await env.announcer.announceEnabled(
+            conversationId: Self.conversationId,
+            agentInboxId: Self.agentInboxId,
+            abilityId: "googlecalendar",
+            bundleIds: []
+        )
+
+        let grants = await env.grantWriter.grantedCalls()
+        #expect(grants.isEmpty)
+    }
+
+    @Test("A recorded grant with a different scope is re-granted without a transcript line")
+    func differentScopeRegrantsSilently() async throws {
+        // The legacy entitlement fallback authorizes from the backend
+        // consent record; skipping here would let a stale wider scope
+        // outlive the member's narrower re-selection. But a scope
+        // correction is not a new connection, so no GRANTED event —
+        // matching the card path's diff-based broadcasting.
+        let env = Self.makeEnv()
+        await env.repository.setConnections([Self.connection()])
+        await env.repository.setGrants([Self.recordedGrant(bundleIds: ["calendar.events", "calendar.freebusy"])])
 
         await env.announcer.announceEnabled(
             conversationId: Self.conversationId,
@@ -153,7 +200,31 @@ struct AbilityGrantAnnouncerTests {
         )
 
         let grants = await env.grantWriter.grantedCalls()
-        #expect(grants.isEmpty)
+        #expect(grants.count == 1)
+        #expect(grants.first?.bundleIds == ["calendar.events"])
+        let events = await env.eventWriter.grantedEvents()
+        #expect(events.isEmpty, "a scope correction is not a new connection")
+    }
+
+    @Test("A legacy full-service record compared against an explicit selection re-grants")
+    func legacyNilScopeVersusExplicitRegrants() async throws {
+        // Nil-vs-explicit cannot be compared locally (nil materializes
+        // from the live catalog inside the writer), so the conservative
+        // direction is to re-push the explicit scope.
+        let env = Self.makeEnv()
+        await env.repository.setConnections([Self.connection()])
+        await env.repository.setGrants([Self.recordedGrant(bundleIds: nil)])
+
+        await env.announcer.announceEnabled(
+            conversationId: Self.conversationId,
+            agentInboxId: Self.agentInboxId,
+            abilityId: "googlecalendar",
+            bundleIds: ["calendar.events"]
+        )
+
+        let grants = await env.grantWriter.grantedCalls()
+        #expect(grants.count == 1)
+        #expect(grants.first?.bundleIds == ["calendar.events"])
         let events = await env.eventWriter.grantedEvents()
         #expect(events.isEmpty)
     }

--- a/ConvosCore/Tests/ConvosCoreTests/AbilityGrantAnnouncerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AbilityGrantAnnouncerTests.swift
@@ -1,0 +1,378 @@
+import Combine
+import ConvosConnections
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// The announcer is a thin resolver in front of the card path's grant
+/// writer; what these tests pin is that a landed per-chat toggle produces
+/// the exact writer effects a capability-card approval does — the grant
+/// (with the picked bundles), the backend consent record it implies, and
+/// the granted/revoked transcript event — and nothing at all when the
+/// grant cannot land.
+@Suite("AbilityGrantAnnouncer Tests")
+struct AbilityGrantAnnouncerTests {
+    private static let conversationId = "conv-1"
+    private static let agentInboxId = "agent-1"
+
+    private static func connection(id: String = "conn-a", connectedAt: Date = Date(timeIntervalSince1970: 0)) -> CloudConnection {
+        CloudConnection(
+            id: id,
+            serviceId: "googlecalendar",
+            serviceName: "Google Calendar",
+            provider: .composio,
+            composioEntityId: "entity-a",
+            composioConnectionId: "cconn-a",
+            status: .active,
+            connectedAt: connectedAt
+        )
+    }
+
+    private static func recordedGrant(connectionId: String = "conn-a") -> CloudConnectionGrant {
+        CloudConnectionGrant(
+            connectionId: connectionId,
+            conversationId: conversationId,
+            serviceId: "googlecalendar",
+            grantedToInboxId: agentInboxId,
+            grantedAt: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    private struct Env {
+        let repository: StubRepository
+        let grantWriter: RecordingGrantWriter
+        let eventWriter: RecordingEventWriter
+        let refreshes: RefreshCounter
+        let announcer: CloudAbilityGrantAnnouncer
+    }
+
+    private static func makeEnv(onRefresh: (@Sendable (StubRepository) async -> Void)? = nil) -> Env {
+        let repository = StubRepository()
+        let grantWriter = RecordingGrantWriter()
+        let eventWriter = RecordingEventWriter()
+        let refreshes = RefreshCounter()
+        let announcer = CloudAbilityGrantAnnouncer(
+            repository: repository,
+            grantWriter: { grantWriter },
+            eventWriter: { eventWriter },
+            refreshConnections: {
+                await refreshes.increment()
+                await onRefresh?(repository)
+            }
+        )
+        return Env(
+            repository: repository,
+            grantWriter: grantWriter,
+            eventWriter: eventWriter,
+            refreshes: refreshes,
+            announcer: announcer
+        )
+    }
+
+    @Test("A landed enable grants through the card path and broadcasts granted")
+    func enableGrantsAndBroadcasts() async throws {
+        let env = Self.makeEnv()
+        await env.repository.setConnections([Self.connection()])
+
+        await env.announcer.announceEnabled(
+            conversationId: Self.conversationId,
+            agentInboxId: Self.agentInboxId,
+            abilityId: "googlecalendar",
+            bundleIds: ["calendar.events"]
+        )
+
+        let refreshCount = await env.refreshes.count()
+        #expect(refreshCount == 0, "an already-hydrated store needs no refresh")
+        let grants = await env.grantWriter.grantedCalls()
+        #expect(grants.count == 1)
+        #expect(grants.first?.connectionId == "conn-a")
+        #expect(grants.first?.conversationId == Self.conversationId)
+        #expect(grants.first?.bundleIds == ["calendar.events"])
+        let events = await env.eventWriter.grantedEvents()
+        #expect(events.count == 1)
+        #expect(events.first?.providerId == "composio.googlecalendar")
+        #expect(events.first?.grantedToInboxId == Self.agentInboxId)
+    }
+
+    @Test("A refresh retry resolves a just-connected ability")
+    func refreshRetryResolves() async throws {
+        // The V2 abilities OAuth just finished: the backend lists the
+        // connection, the local store hasn't seen it yet. The (delta,
+        // cascade-safe) refresh is what hydrates it.
+        let env = Self.makeEnv(onRefresh: { repository in
+            await repository.setConnections([Self.connection()])
+        })
+
+        await env.announcer.announceEnabled(
+            conversationId: Self.conversationId,
+            agentInboxId: Self.agentInboxId,
+            abilityId: "googlecalendar",
+            bundleIds: ["calendar.events"]
+        )
+
+        let refreshCount = await env.refreshes.count()
+        #expect(refreshCount == 1)
+        let grants = await env.grantWriter.grantedCalls()
+        #expect(grants.count == 1)
+    }
+
+    @Test("A missing connection skips without granting or broadcasting")
+    func missingConnectionSkips() async throws {
+        let env = Self.makeEnv()
+
+        await env.announcer.announceEnabled(
+            conversationId: Self.conversationId,
+            agentInboxId: Self.agentInboxId,
+            abilityId: "googlecalendar",
+            bundleIds: ["calendar.events"]
+        )
+
+        let refreshCount = await env.refreshes.count()
+        #expect(refreshCount == 1)
+        let grants = await env.grantWriter.grantedCalls()
+        #expect(grants.isEmpty, "nothing to grant against")
+        let events = await env.eventWriter.grantedEvents()
+        #expect(events.isEmpty, "no transcript line for a grant that never landed")
+    }
+
+    @Test("An already-recorded grant announces nothing")
+    func alreadyRecordedIsIdempotent() async throws {
+        // Mirrors AgentBuilderConnectionGrantReplayer's repository-based
+        // idempotency: no duplicate backend push, no duplicate transcript
+        // line for a grant the card path (or an earlier toggle) already
+        // announced.
+        let env = Self.makeEnv()
+        await env.repository.setConnections([Self.connection()])
+        await env.repository.setGrants([Self.recordedGrant()])
+
+        await env.announcer.announceEnabled(
+            conversationId: Self.conversationId,
+            agentInboxId: Self.agentInboxId,
+            abilityId: "googlecalendar",
+            bundleIds: ["calendar.events"]
+        )
+
+        let grants = await env.grantWriter.grantedCalls()
+        #expect(grants.isEmpty)
+        let events = await env.eventWriter.grantedEvents()
+        #expect(events.isEmpty)
+    }
+
+    @Test("An empty bundle selection becomes full-service consent, not an empty scope")
+    func emptyBundlesBecomeNil() async throws {
+        let env = Self.makeEnv()
+        await env.repository.setConnections([Self.connection()])
+
+        await env.announcer.announceEnabled(
+            conversationId: Self.conversationId,
+            agentInboxId: Self.agentInboxId,
+            abilityId: "googlecalendar",
+            bundleIds: []
+        )
+
+        let grants = await env.grantWriter.grantedCalls()
+        #expect(grants.first?.bundleIds == nil, "the writer fails closed on an empty explicit selection")
+    }
+
+    @Test("A failed grant writes no transcript line and does not throw")
+    func failedGrantBroadcastsNothing() async throws {
+        let env = Self.makeEnv()
+        await env.repository.setConnections([Self.connection()])
+        await env.grantWriter.setShouldThrow(true)
+
+        await env.announcer.announceEnabled(
+            conversationId: Self.conversationId,
+            agentInboxId: Self.agentInboxId,
+            abilityId: "googlecalendar",
+            bundleIds: ["calendar.events"]
+        )
+
+        let events = await env.eventWriter.grantedEvents()
+        #expect(events.isEmpty)
+    }
+
+    @Test("A landed disable revokes the recorded grants and broadcasts revoked")
+    func disableRevokesAndBroadcasts() async throws {
+        let env = Self.makeEnv()
+        await env.repository.setGrants([Self.recordedGrant()])
+
+        await env.announcer.announceDisabled(
+            conversationId: Self.conversationId,
+            agentInboxId: Self.agentInboxId,
+            abilityId: "googlecalendar"
+        )
+
+        let revokes = await env.grantWriter.revokedCalls()
+        #expect(revokes.count == 1)
+        #expect(revokes.first?.connectionId == "conn-a")
+        let events = await env.eventWriter.revokedEvents()
+        #expect(events.count == 1)
+        #expect(events.first?.providerId == "composio.googlecalendar")
+        #expect(events.first?.grantedToInboxId == Self.agentInboxId)
+    }
+
+    @Test("A disable with nothing recorded is a silent no-op")
+    func disableWithNothingRecordedIsNoOp() async throws {
+        // A toggle that was never announced (written before announcements
+        // existed) has no rows; the withdraw must not manufacture a revoke
+        // or put a "removed" line in the transcript over a no-op.
+        let env = Self.makeEnv()
+
+        await env.announcer.announceDisabled(
+            conversationId: Self.conversationId,
+            agentInboxId: Self.agentInboxId,
+            abilityId: "googlecalendar"
+        )
+
+        let revokes = await env.grantWriter.revokedCalls()
+        #expect(revokes.isEmpty)
+        let events = await env.eventWriter.revokedEvents()
+        #expect(events.isEmpty)
+    }
+}
+
+// MARK: - Mocks
+
+private actor StubRepository: CloudConnectionRepositoryProtocol {
+    private var storedConnections: [CloudConnection] = []
+    private var storedGrants: [CloudConnectionGrant] = []
+
+    func setConnections(_ connections: [CloudConnection]) {
+        storedConnections = connections
+    }
+
+    func setGrants(_ grants: [CloudConnectionGrant]) {
+        storedGrants = grants
+    }
+
+    func connections() async throws -> [CloudConnection] {
+        storedConnections
+    }
+
+    nonisolated func connectionsPublisher() -> AnyPublisher<[CloudConnection], Never> {
+        Just([]).eraseToAnyPublisher()
+    }
+
+    func grants(for conversationId: String) async throws -> [CloudConnectionGrant] {
+        storedGrants.filter { $0.conversationId == conversationId }
+    }
+
+    nonisolated func grantsPublisher(for conversationId: String) -> AnyPublisher<[CloudConnectionGrant], Never> {
+        Just([]).eraseToAnyPublisher()
+    }
+}
+
+private actor RecordingGrantWriter: CloudConnectionGrantWriterProtocol {
+    struct GrantCall: Sendable, Equatable {
+        let connectionId: String
+        let conversationId: String
+        let grantedToInboxId: String
+        let bundleIds: [String]?
+    }
+
+    struct RevokeCall: Sendable, Equatable {
+        let connectionId: String
+        let conversationId: String
+        let grantedToInboxId: String
+    }
+
+    private var grants: [GrantCall] = []
+    private var revokes: [RevokeCall] = []
+    private var shouldThrow: Bool = false
+
+    func setShouldThrow(_ value: Bool) {
+        shouldThrow = value
+    }
+
+    func grantedCalls() -> [GrantCall] { grants }
+    func revokedCalls() -> [RevokeCall] { revokes }
+
+    func grantConnection(
+        _ connectionId: String,
+        to conversationId: String,
+        grantedToInboxId: String,
+        bundleIds: [String]?
+    ) async throws {
+        if shouldThrow { throw StubError.pushFailed }
+        grants.append(
+            GrantCall(
+                connectionId: connectionId,
+                conversationId: conversationId,
+                grantedToInboxId: grantedToInboxId,
+                bundleIds: bundleIds
+            )
+        )
+    }
+
+    func grantConnectionConfirmingBackend(
+        _ connectionId: String,
+        to conversationId: String,
+        grantedToInboxId: String,
+        bundleIds: [String]?
+    ) async throws {
+        try await grantConnection(connectionId, to: conversationId, grantedToInboxId: grantedToInboxId, bundleIds: bundleIds)
+    }
+
+    func revokeGrant(
+        connectionId: String,
+        from conversationId: String,
+        grantedToInboxId: String
+    ) async throws {
+        if shouldThrow { throw StubError.pushFailed }
+        revokes.append(
+            RevokeCall(
+                connectionId: connectionId,
+                conversationId: conversationId,
+                grantedToInboxId: grantedToInboxId
+            )
+        )
+    }
+
+    enum StubError: Error {
+        case pushFailed
+    }
+}
+
+private actor RecordingEventWriter: ConnectionEventWriterProtocol {
+    struct Call: Sendable {
+        let providerId: String
+        let grantedToInboxId: String?
+        let conversationId: String
+    }
+
+    private var grants: [Call] = []
+    private var revocations: [Call] = []
+
+    func grantedEvents() -> [Call] { grants }
+    func revokedEvents() -> [Call] { revocations }
+
+    func sendGranted(
+        providerId: String,
+        capability: ConnectionCapability?,
+        grantedToInboxId: String?,
+        in conversationId: String
+    ) async throws {
+        grants.append(Call(providerId: providerId, grantedToInboxId: grantedToInboxId, conversationId: conversationId))
+    }
+
+    func sendRevoked(
+        providerId: String,
+        capability: ConnectionCapability?,
+        grantedToInboxId: String?,
+        in conversationId: String
+    ) async throws {
+        revocations.append(Call(providerId: providerId, grantedToInboxId: grantedToInboxId, conversationId: conversationId))
+    }
+}
+
+private actor RefreshCounter {
+    private var value: Int = 0
+
+    func increment() {
+        value += 1
+    }
+
+    func count() -> Int {
+        value
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
@@ -604,6 +604,46 @@ struct ConnectionManagerTests {
             // expected: the sheet surfaces this instead of hanging
         }
     }
+
+    @Test("Deleting a conversation cascades its grant rows away")
+    func conversationDeleteCascadesGrants() async throws {
+        // Pins the platform difference with Android, where foreign-key
+        // enforcement is off and an explicit cleaner reaps grant rows on
+        // conversation deletion. Here `foreignKeysEnabled = true`
+        // (DatabaseManager, and GRDB's default in this test database)
+        // makes `connectionGrant.conversationId ON DELETE CASCADE` live:
+        // every deletion path (explosion reap, leave, quarantine) relies
+        // on it, and nothing may re-create Android-style orphan rows. If
+        // this test ever fails because enforcement was turned off, grant
+        // hygiene needs an explicit cleaner before shipping.
+        let fixtures = try await makeTestFixtures()
+        let keptConversationId = "convo-kept"
+        let deletedConversationId = "convo-deleted"
+
+        try await fixtures.dbWriter.write { db in
+            try makeDBConversation(id: keptConversationId).insert(db)
+            try makeDBConversation(id: deletedConversationId).insert(db)
+            try makeDBConnection(id: "conn-1").insert(db)
+            for conversationId in [keptConversationId, deletedConversationId] {
+                try DBCloudConnectionGrant(
+                    connectionId: "conn-1",
+                    conversationId: conversationId,
+                    serviceId: "googlecalendar",
+                    grantedToInboxId: "agent-1",
+                    grantedAt: Date()
+                ).insert(db)
+            }
+        }
+
+        _ = try await fixtures.dbWriter.write { db in
+            try DBConversation.deleteOne(db, key: deletedConversationId)
+        }
+
+        let remaining = try await fixtures.dbReader.read { db in
+            try DBCloudConnectionGrant.fetchAll(db)
+        }
+        #expect(remaining.map(\.conversationId) == [keptConversationId])
+    }
 }
 
 // MARK: - Helpers

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionsMetadataPayloadTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionsMetadataPayloadTests.swift
@@ -104,6 +104,41 @@ struct ConnectionsMetadataPayloadTests {
         #expect(grant.grantedAt == "2026-04-21T15:33:01Z")
     }
 
+    @Test("Round-trips the conversationId scope field")
+    func roundTripConversationId() throws {
+        // Additive (2026-08), wire-parity with Android: the field is what
+        // lets the runtime grow a per-conversation grant filter in one
+        // server deploy covering both platforms.
+        let scoped = CloudConnectionGrantEntry(
+            id: "grant_conn_123",
+            senderId: "sender_abc",
+            grantedToInboxId: "agent_xyz",
+            service: "googlecalendar",
+            provider: "composio",
+            composioEntityId: "entity_device",
+            composioConnectionId: "ca_abc",
+            grantedAt: "2026-04-21T15:00:00Z",
+            conversationId: "conv-1"
+        )
+        let payload = CloudConnectionsMetadataPayload(grants: [scoped])
+
+        let json = try payload.toJsonString()
+        let decoded = try CloudConnectionsMetadataPayload.fromJsonString(json)
+        #expect(decoded.grants.first?.conversationId == "conv-1")
+    }
+
+    @Test("A legacy entry without conversationId decodes as unknown, and nil never serialises")
+    func legacyEntriesOmitConversationId() throws {
+        // Absence means "conversation unknown", never "applies everywhere" -
+        // and an entry built without the field must not add a null key that
+        // older readers would choke on.
+        let legacyJson = try CloudConnectionsMetadataPayload(grants: [entry()]).toJsonString()
+        #expect(!legacyJson.contains("conversationId"))
+
+        let decoded = try CloudConnectionsMetadataPayload.fromJsonString(legacyJson)
+        #expect(decoded.grants.first?.conversationId == nil)
+    }
+
     @Test("Malformed JSON throws")
     func malformedJsonThrows() {
         #expect(throws: (any Error).self) {


### PR DESCRIPTION
iOS counterpart of the Android agent-awareness fixes ([convos-client#199](https://github.com/xmtplabs/convos-client/pull/199) and the applicable subset of [convos-client#200](https://github.com/xmtplabs/convos-client/pull/200)), for the Connections v2 rollout. Three commits, reviewable independently.

## The problem

Connection grants live in two ledgers: the backend entitlement tables (which authorize exec) and the profile-metadata `connections` payload (which the agent runtime's connections skill actually *reads*). The abilities per-chat toggles wrote only the first — so a member could connect a service, toggle it on for a convo, ask the agent to use it, and still get an approval card for consent they'd already given.

## Commit 1 — scope the composer browser to the origin group

`handleComposerConnectionsTap` passed the agent DM's own conversation id into the browser modal, but the backend authorizes the agent's tool calls against its **primary group** — the exact rule `CapabilityGrantScope` already enforces for card approvals ("a grant scoped to the DM's own id authorizes nothing"). The toggles were writing opt-ins against the wrong conversation. Now passes the hosting group's id. (Android's identical fix: convos-client#198.)

## Commit 2 — the announcer

New `CloudAbilityGrantAnnouncer`: after a landed extend, it routes through the same `CloudConnectionGrantWriter` the capability-card path uses, so a toggle-on becomes equivalent to approving a card — the metadata payload the runtime reads, the backend `ConnectionGrant` consent record, and the in-chat granted `ConnectionEvent` transcript line. Withdraw revokes the recorded rows symmetrically (revoked broadcast only when rows actually existed). Idempotent by repository check (the `AgentBuilderConnectionGrantReplayer` pattern); connection resolution is most-recent-active by serviceId with one **delta** `refreshConnections` retry; best-effort throughout — a failed announcement logs and degrades to today's behavior (the agent cards once), never reverting the toggle. Wired through `AbilitiesSelection` so both the browser modal (including connect-from-Discover) and the conversation-info section announce, with zero construction-site changes.

**On #1442**: this deliberately revives the ground the deleted v1 awareness shim covered, with different semantics — production-on by design and full card-path equivalence, rather than a default-off raw-JSON side-write. The prod rollout is what surfaced the gap the shim was probing at.

## Commit 3 — `conversationId` on metadata grant entries

The honest subset of convos-client#200. Its two big pieces deliberately do **not** port: iOS's `connections` key is conversation-scoped (`DBSelfConversationMetadata` + `ProfilePublisher`'s scoped merge), so Android's canonical-profile clobber never existed here and porting the all-conversations projection would leak grants across conversations; and orphan cleanup already happens via the live FK cascade (`foreignKeysEnabled`), which a new test now pins — documenting the platform difference with Android, where enforcement is off and an explicit cleaner does the reaping. What does port: grant entries gain an optional `conversationId` (field name matching Android exactly), which is what lets the runtime grow a per-conversation grant filter in one server deploy covering both platforms. Absent-means-unknown; nil never serialises, so legacy payloads are byte-identical.

## Verification

- New `AbilityGrantAnnouncerTests` (8 tests), payload round-trip/absence tests, and the cascade pin — 65 tests green across the four touched ConvosCore suites (`AbilityGrantAnnouncer`, `ConnectionsMetadataPayload`, `ConnectionGrantWriter`, `CloudConnectionManager`).
- `Convos (Dev)` simulator build (iPhone 17 Pro, arm64): BUILD SUCCEEDED. (The x86_64 slice of a generic-simulator destination fails to link `NotificationService` on clean `dev` too — pre-existing, unrelated.)
- SwiftFormat/SwiftLint clean (pre-commit + pre-push hooks).
- Full integration suite deferred to CI (needs the local XMTP node).

## Follow-ups (out of scope)

Runtime-side: `connections.mjs` filtering grant entries by `conversationId` closes the cross-conversation read leak on both platforms; longer-term, the skill consulting `checkEntitlement` directly would obsolete client-side announcing. Cross-platform: Android's canonical vs iOS's conversation-scoped `connections` metadata models have diverged and deserve an ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvSn5kjdB9N2GAS9DCpXSG

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `CloudAbilityGrantAnnouncer` to publish per-chat ability grants to agent runtime
> - Introduces `AbilityGrantAnnouncing` protocol and `CloudAbilityGrantAnnouncer` class in [AbilityGrantAnnouncer.swift](https://github.com/xmtplabs/convos-ios/pull/1453/files#diff-f9fb35282e4cde1615790d4bc086770d9f45d8cf627138fb511cf79b3890279c) to best-effort announce per-conversation ability grants and revocations, including transcript events for first-time grants/revokes.
> - Wires the announcer through `AbilitiesServices.configure` into `AbilitiesSelection.announcer` so view-models in live mode can publish grants; remains nil in mock mode.
> - `ConversationAbilitiesViewModel` now calls `announceEnabled`/`announceDisabled` after successful `extendAbility`/`withdrawAbility`; failures are swallowed.
> - Adds optional `conversationId` to `CloudConnectionGrantEntry` and uses the grant's own `conversationId` in profile metadata entry ids.
> - Fixes `ConversationView.handleComposerConnectionsTap` to scope toggles to the origin group conversation id instead of the DM id.
> - Behavioral Change: `CloudConnectionGrantEntry` now serializes an additional `conversationId` key when present; legacy entries without it still decode as nil. Announcements are fire-and-forget with swallowed failures, so no user-facing flow blocks on announcement errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 06c4827.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->