### PR TITLE
Report libxmtp telemetry into Sentry alongside the app's own events

### DIFF
--- a/Convos/Config/LibxmtpSentry.swift
+++ b/Convos/Config/LibxmtpSentry.swift
@@ -1,0 +1,71 @@
+import ConvosCore
+import Foundation
+import XMTPiOS
+
+/// Bridges the app onto libxmtp's Sentry telemetry, so the Rust layer's spans
+/// and errors land in the same Sentry project as the app's own events.
+///
+/// Every reference to the telemetry surface (`enableSentryTelemetry`,
+/// `setSentryUser`, `flushTelemetry`, `FfiSentryConfig`, `FfiSentryTag`) lives
+/// in this one file on purpose. Those symbols are uniffi codegen output that
+/// ships inside the `XMTPiOS` module, so their spelling, argument labels, and
+/// throwing-ness are decided by libxmtp's bindings rather than by hand-written
+/// SDK code. Keeping the whole surface here makes a codegen rename a one-file
+/// fix instead of a scatter of call-site edits.
+enum LibxmtpSentry {
+    /// Production sends no traces: they carry per-operation timing for every
+    /// send and sync, and the volume is not worth paying for until the
+    /// internal builds show which spans are worth keeping.
+    private static let productionTracesSampleRate: Float = 0.0
+    private static let internalTracesSampleRate: Float = 0.1
+
+    /// Matches the Sentry SDK's own default, and bounds how much libxmtp
+    /// buffers between events.
+    private static let maxBreadcrumbs: UInt32 = 100
+
+    /// Enables libxmtp telemetry wherever the Swift Sentry SDK is also enabled,
+    /// reporting under the same DSN and environment name so both sources sit
+    /// side by side. Never throws out to the caller: telemetry must not be able
+    /// to take down launch.
+    static func configure(environment: AppEnvironment) {
+        guard SentryConfiguration.shouldEnableSentry(for: environment) else {
+            Log.info("libxmtp Sentry telemetry disabled for environment: \(environment.name)")
+            return
+        }
+
+        let dsn = Secrets.SENTRY_DSN
+        guard !dsn.isEmpty else {
+            Log.warning("Sentry DSN is empty, skipping libxmtp telemetry")
+            return
+        }
+
+        let sentryEnvironment = SentryConfiguration.environmentName(for: environment)
+        let tracesSampleRate = environment.isProduction ? productionTracesSampleRate : internalTracesSampleRate
+        do {
+            try enableSentryTelemetry(config: FfiSentryConfig(
+                dsn: dsn,
+                environment: sentryEnvironment,
+                release: nil,
+                tracesSampleRate: tracesSampleRate,
+                maxBreadcrumbs: maxBreadcrumbs,
+                userStableId: nil,
+                tags: []
+            ))
+            Log.info("libxmtp Sentry telemetry enabled for environment: \(sentryEnvironment) (tracesSampleRate: \(tracesSampleRate))")
+        } catch {
+            Log.error("Failed to enable libxmtp Sentry telemetry: \(error.localizedDescription)")
+        }
+    }
+
+    /// Tags libxmtp's telemetry with the id PostHog identifies the person by,
+    /// so a Sentry issue and a product-analytics person resolve to the same
+    /// user without either side carrying the raw inbox id.
+    static func setUser(stableId: String) {
+        setSentryUser(stableId: stableId)
+    }
+
+    /// Drains buffered telemetry before the system can suspend the process.
+    static func flush() {
+        flushTelemetry()
+    }
+}

--- a/Convos/Config/SentryConfiguration.swift
+++ b/Convos/Config/SentryConfiguration.swift
@@ -18,6 +18,7 @@ enum SentryConfiguration {
 
         let envName = environment.name
         let isProduction = environment.isProduction
+        let sentryEnvironment = environmentName(for: environment)
         Log.info("Initializing Sentry for environment: \(envName)")
 
         SentrySDK.start { options in
@@ -30,6 +31,7 @@ enum SentryConfiguration {
             // and the next launch re-foregrounds the frozen one.
             options.enableSigtermReporting = false
             options.attachStacktrace = true
+            options.environment = sentryEnvironment
 
             if isProduction {
                 // Crash and error reporting only. Screenshots, view hierarchy,
@@ -38,7 +40,6 @@ enum SentryConfiguration {
                 options.attachScreenshot = false
                 options.attachViewHierarchy = false
                 options.sendDefaultPii = false
-                options.environment = envName
             } else {
                 // Richer context (screenshots, view hierarchy, IP addresses,
                 // user IDs, request data) for internal team debugging.
@@ -47,14 +48,23 @@ enum SentryConfiguration {
                 options.attachScreenshot = true
                 options.attachViewHierarchy = true
                 options.sendDefaultPii = true
-                options.environment = "\(envName)-debug"
             }
         }
 
         Log.info("Sentry initialized successfully")
     }
 
-    private static func shouldEnableSentry(for environment: AppEnvironment) -> Bool {
+    /// The environment events report under. Non-production builds get a
+    /// `-debug` suffix so their richer, PII-carrying events stay separable from
+    /// production. Shared with `LibxmtpSentry` so libxmtp's telemetry lands in
+    /// the same environment as the Swift SDK's events.
+    static func environmentName(for environment: AppEnvironment) -> String {
+        environment.isProduction ? environment.name : "\(environment.name)-debug"
+    }
+
+    /// Also gates libxmtp's telemetry, so the two event sources are never
+    /// enabled independently of each other.
+    static func shouldEnableSentry(for environment: AppEnvironment) -> Bool {
         switch environment {
         case .local, .tests:
             // Local builds and test runs never report to Sentry

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -92,6 +92,13 @@ struct ConvosApp: App {
             Client.setLibXMTPNativeLogLevel(libXMTPLogLevel)
             Log.info("LibXMTP native log level set to \(libXMTPLogLevel)")
         }
+
+        // libxmtp reports its own errors and spans into the same Sentry project
+        // as the app, so a protocol-layer failure shows up next to the app-side
+        // event it caused. Enabled after the log writer is scheduled so both
+        // native sinks are configured before any client work starts.
+        LibxmtpSentry.configure(environment: environment)
+
         Log.info("App starting with environment: \(environment)")
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
         let appBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
@@ -205,7 +212,15 @@ struct ConvosApp: App {
             do {
                 let messagingService = session.messagingService()
                 let inboxReady = try await messagingService.sessionStateManager.waitForInboxReadyResult()
-                coreMetrics.identify(privateKey: Data(inboxReady.client.inboxId.utf8))
+                let inboxKey = Data(inboxReady.client.inboxId.utf8)
+                coreMetrics.identify(privateKey: inboxKey)
+                // Deriving the id the same way PostHog does makes the Sentry
+                // user and the product-analytics person the same identifier,
+                // so an error and the session it broke can be lined up without
+                // either side carrying the inbox id.
+                LibxmtpSentry.setUser(
+                    stableId: PostHogConfiguration.stableIdEncoder.derive(privateKey: inboxKey)
+                )
                 // The backend accountId (not the XMTP inbox id) lets product
                 // analytics cross-link to backend records. Backend SIWE auth
                 // caches it in the keychain before the session reaches inbox
@@ -320,6 +335,9 @@ struct ConvosApp: App {
                 case .active:
                     handleScenePhaseActive()
                 case .background:
+                    // Push whatever libxmtp has buffered out now; a suspended
+                    // process may never get another chance to send it.
+                    LibxmtpSentry.flush()
                     // Re-arm once-per-foreground work for the next active session.
                     timezoneForegroundGuard.reset()
                     agentRelayForegroundGuard.reset()

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -29,6 +29,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/groue/GRDB.swift.git", exact: "7.5.0"),
+        // ConvosInvites/Package.swift pins the same revision and has to move with this one, or SPM
+        // fails to resolve two revisions of the same package.
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
             revision: "ios-4.12.0-dev.de26965"


### PR DESCRIPTION
libxmtp now ships a Sentry telemetry FFI, so the Rust layer can report its own
errors and spans instead of only leaving them in the rotating file log. This
wires the iOS app onto it.

## What this wires

- **`Convos/Config/LibxmtpSentry.swift`** (new) — the whole adapter. It reads
  the same `Secrets.SENTRY_DSN`, reports under the same environment name, and
  is gated by the same `shouldEnableSentry(for:)` decision the Swift Sentry SDK
  uses, so the two event sources are never enabled independently. Traces are
  sampled at 0.1 on non-production and 0.0 on production; `maxBreadcrumbs` is
  100; no release string and no tags for now. Nothing here can throw out to a
  caller: a failure logs and the app carries on.
- **`Convos/ConvosApp.swift`**
  - `init()` — `LibxmtpSentry.configure(environment:)` right after the libxmtp
    log writer is scheduled, so both native sinks are set before client work.
  - `startMetricsIdentification` — `LibxmtpSentry.setUser(stableId:)` at the
    same inbox-ready point that calls `coreMetrics.identify`.
  - scene phase `.background` — `LibxmtpSentry.flush()`, so a process the
    system is about to suspend doesn't sit on buffered events.
- **`Convos/Config/SentryConfiguration.swift`** — `shouldEnableSentry(for:)` is
  no longer private, and the `-debug` environment suffix moved into a shared
  `environmentName(for:)`. Behavior-preserving; it just gives the adapter one
  source of truth to read instead of a second copy of the same rules.

## Stable-id parity with PostHog

`setUser` derives its id through `PostHogConfiguration.stableIdEncoder`
(`MetricsStableIdEncoder`, HKDF-SHA256 over the inbox id with salt
`convos-metrics` / info `inbox-stable-id`) — the same instance and the same
input `CoreMetrics.identify` uses. The Sentry user id is therefore
byte-identical to the PostHog person id, so an error and the session that
produced it line up across the two tools without either side carrying the raw
inbox id.

## Dependency: the SDK bump

The pinned libxmtp revision predates the telemetry FFI, so **the app-building
job (`firebase_pr`) is expected to be red on this PR until the SDK moves**. The
unit and integration jobs build `ConvosCore` only, which this PR does not
touch, so they should stay green. The functions
(`enableSentryTelemetry`, `setSentryUser`, `flushTelemetry`) and records
(`FfiSentryConfig`, `FfiSentryTag`) are uniffi codegen output that lands in the
`XMTPiOS` module; the pin to bump is in `ConvosCore/Package.swift` (marked with
a `TODO(libxmtp-sentry)`), and `ConvosInvites/Package.swift` pins the same
revision and has to move with it or SPM cannot resolve.

Their exact spelling, argument labels, and throwing-ness are decided by
libxmtp's codegen rather than by hand-written SDK code, which is why every
reference to them is deliberately confined to `LibxmtpSentry.swift`. If the
generated names differ from what this PR assumes, the fix is that one file —
and the current CI failure demonstrates it. `firebase_pr` reports exactly four
diagnostics, all in `LibxmtpSentry.swift`:

```
LibxmtpSentry.swift:49:17: cannot find 'enableSentryTelemetry' in scope
LibxmtpSentry.swift:49:47: cannot find 'FfiSentryConfig' in scope
LibxmtpSentry.swift:68:9:  cannot find 'setSentryUser' in scope
LibxmtpSentry.swift:73:9:  cannot find 'flushTelemetry' in scope
```

## Verification

Compile-checked on an Xcode 26.4 machine: `xcodebuild -scheme 'Convos (Dev)'
-destination 'generic/platform=iOS Simulator' ARCHS=arm64` — **BUILD
SUCCEEDED**, with the four not-yet-shipped symbols swapped for local stubs to
prove that everything except those symbols compiles and links. The stubs are
not part of this branch.

Two incidental findings from that run, neither caused by this PR: the default
`generic/platform=iOS Simulator` build fails at link because
`LibXMTPSwiftFFI.xcframework` ships no x86_64 simulator slice (arm64 only), and
a fresh checkout needs `make secrets` before the `Convos/Config/Secrets.swift`
references resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `LibxmtpSentry` bridge to report libxmtp telemetry into Sentry
> - Adds `LibxmtpSentry` with `configure`, `setUser`, and `flush` methods that forward libxmtp telemetry to the same Sentry DSN/environment the app uses, with `tracesSampleRate` of `0.0` in production and `0.1` elsewhere
> - Refactors `SentryConfiguration` to expose `environmentName(for:)` and `shouldEnableSentry(for:)` as `internal` helpers shared by both the app and the libxmtp bridge
> - Wires startup, user identification, and background flush in [ConvosApp.swift](https://github.com/xmtplabs/convos-ios/pull/1454/files#diff-de23c5a6e10cb84b89d91ed62b707b654c28566f38cc339af8b3cbbf6e003014): libxmtp telemetry is configured at launch, tagged with a stable user id derived from the inbox key, and flushed when the app enters background
> - Risk: `SentryConfiguration.shouldEnableSentry` access changed from `private` to `internal`; verify no other consumers depend on it being private
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef09f89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->