### PR TITLE
chore(deps): bump convos-releases flake input for the branch-version guard

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787597267,
-        "narHash": "sha256-VR4Mlp+sH4UYJIha/rFrMrWf7ckKEO+J0XcGKcdvI74=",
+        "lastModified": 1787863956,
+        "narHash": "sha256-Myd1oDwsOwh8H2z5GrTczFFqS8gjM7h/ecc/JBhDr/k=",
         "owner": "xmtplabs",
         "repo": "convos-releases",
-        "rev": "9d842688523b98efde913c192f1a29f08ace0a12",
+        "rev": "a270c2aaf3f94167e2af12d7e7563c8b66838527",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps the `convos-releases` flake input to `a270c2aa`.

**Why now.** The RC upload workflows are consumed `@main` and, as of [convos-releases#44](https://github.com/xmtplabs/convos-releases/pull/44), call `train check-branch-version` before every release/hotfix build. `train` comes from this repo's dev shell, which resolves *this* `flake.lock` — so until it moves, those uploads fail with `train: unknown command 'check-branch-version'`.

**What the guard does.** A release branch advanced to `dev` (merge or fast-forward) inherits dev's post-cut version bump, so the build reaches the store stamped one version while the train ledger records another. That is how convos-client shipped 2.5.0 to Play stamped `VERSION_NAME=2.6.0`. The guard compares the branch's version file against the version its name claims, before the build — a consumed versionCode/build number is never reusable, so failing after the upload is too late.

This also activates `Promote#prepare`'s `assert_rc_version`, which re-checks the RC's own blob before tagging.

**Verified** from the bumped dev shell:

```
$ nix develop ./ --command train check-branch-version --ref release/2.6.0
train: release/2.6.0 carries version 2.7.0, but the branch claims 2.6.0. ...
```

(reported against this branch's `dev` checkout at 2.7.0, which is the correct answer for that pairing.)

**Note:** `release/2.6.0` needs the same bump on its own branch — a release branch's lock is frozen at cut time, and that is the branch RCs build from. Being done separately, as a lock-only change; merging `dev` into the release branch would drag dev's 2.7.0 version across, which is the exact bug this guard exists to catch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790457092&installation_model_id=20076&pr_number=1458&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1458&signature=e23d780f3fb3d7083bb0c48b5951a6a936aaf6ee2333342d94c7c1836c5da8a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `convos-releases` flake input for branch-version guard
> Updates [flake.lock](https://github.com/xmtplabs/convos-ios/pull/1458/files#diff-216b2b7bfde9416c79d133bacb031e95702a20bdedb548c0b055c837aa4f6a9c) to pin the latest `convos-releases` input used by the branch-version guard. No source code changes are involved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a82bcf6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->