### PR TITLE
chore(deps): bump convos-releases flake input on release/2.6.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787597267,
-        "narHash": "sha256-VR4Mlp+sH4UYJIha/rFrMrWf7ckKEO+J0XcGKcdvI74=",
+        "lastModified": 1787863956,
+        "narHash": "sha256-Myd1oDwsOwh8H2z5GrTczFFqS8gjM7h/ecc/JBhDr/k=",
         "owner": "xmtplabs",
         "repo": "convos-releases",
-        "rev": "9d842688523b98efde913c192f1a29f08ace0a12",
+        "rev": "a270c2aaf3f94167e2af12d7e7563c8b66838527",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Lock-only bump of the `convos-releases` flake input to `a270c2aa`, on the release branch itself.

**Why this branch and not just `dev`.** The RC upload workflows are consumed `@main` and, as of [convos-releases#44](https://github.com/xmtplabs/convos-releases/pull/44), call `train check-branch-version` before every release/hotfix build. `train` comes from the dev shell, which resolves *this branch's* `flake.lock` — and a release branch's lock is frozen at cut time. So without this, every push to `release/2.6.0` fails its RC upload with `train: unknown command 'check-branch-version'`. Bumping `dev` does not reach this branch.

It also activates `Promote#prepare`'s `assert_rc_version` for the 2.6.0 promotion: promotion runs on `main` after this branch merges, so `main` inherits this lock.

**Deliberately not a merge from `dev`.** `dev` is at 2.7.0. Merging it here would rewrite this branch's version file to 2.7.0 — precisely the drift the guard exists to catch, and the mechanism by which convos-client shipped 2.5.0 to Play stamped `VERSION_NAME=2.6.0`. Only `flake.lock` changes here; the version file is untouched at 2.6.0.

**Expect an RC upload on merge.** This repo's caller runs on `push` to `release/[0-9]*.[0-9]*.[0-9]*`, so landing this uploads a fresh RC and records it in the manifest — which is the point: it will be the first build to run through the new guard, and it should pass, since this branch reads 2.6.0.

Paired with the `dev` bump so the next cut starts current.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790457141&installation_model_id=20076&pr_number=1459&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1459&signature=0028c5f0a315da46bb69287d50a19355e9cb937889b9f2bbd5f9992a17b55087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `convos-releases` flake input on `release/2.6.0`
> Updates the `convos-releases` flake input in [flake.lock](https://github.com/xmtplabs/convos-ios/pull/1459/files#diff-216b2b7bfde9416c79d133bacb031e95702a20bdedb548c0b055c837aa4f6a9c) to the latest revision. This is a routine lock-file bump on the release branch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 158fbff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->