### PR TITLE
fix(agent-model): adopt a switch that synced during a local write

### DIFF
--- a/ConvosCore/Sources/ConvosComposer/AgentModelStore.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentModelStore.swift
@@ -358,10 +358,30 @@ public final class AgentModelStore {
             )
             if !snapshot.available.isEmpty { options = snapshot.available }
             confirmedId = option.id
-            // This tap is what the server holds now, so anything that synced
-            // while it was in flight is older than it and must not survive to
-            // be restored by a later rollback.
-            deferredSyncedModel = nil
+            // A value that synced while this write was out is the room's own
+            // state, and the room is what the picker exists to show. Adopt it
+            // once this is the last write in flight, rather than dropping it
+            // for the local tap.
+            //
+            // Dropping it looks right — the tap is the thing the server just
+            // acknowledged — and is wrong in one case that does not repair
+            // itself. Both devices write the group's appData, so the room
+            // converges on whichever commit ordered last. If that is the other
+            // member's, appData already carries their value, the republished
+            // value is identical to the one already observed, and no further
+            // change arrives to correct this device: the picker sits on the
+            // local tap while every other member sees the other model, until
+            // the card is closed and reopened.
+            //
+            // Adopting can briefly show a model the room then moves off, but
+            // that resolves on the next synced change. Divergence does not.
+            if let deferred = deferredSyncedModel, writesInFlight == 1 {
+                deferredSyncedModel = nil
+                if deferred != option.id {
+                    selectedId = deferred
+                    confirmedId = deferred
+                }
+            }
             Log.info("agent model set to \(option.id)")
         } catch {
             Log.error("agent model update failed: \(error)")

--- a/ConvosTests/AgentModelStoreSyncRaceTests.swift
+++ b/ConvosTests/AgentModelStoreSyncRaceTests.swift
@@ -10,6 +10,8 @@ private actor ScriptedModelService: AgentModelServing {
     private let catalogue: [AgentModelOption]
     private var pendingReads: [CheckedContinuation<Void, Never>] = []
     private var holdsReads: Bool = false
+    private var pendingWrites: [String: CheckedContinuation<Void, Never>] = [:]
+    private var holdsWrites: Bool = false
 
     init(serverModel: String?, catalogue: [AgentModelOption]) {
         self.serverModel = serverModel
@@ -32,6 +34,20 @@ private actor ScriptedModelService: AgentModelServing {
         }
     }
 
+    func holdWrites(_ holds: Bool) {
+        holdsWrites = holds
+    }
+
+    func releaseWrite(_ model: String) {
+        pendingWrites.removeValue(forKey: model)?.resume()
+    }
+
+    func waitForPendingWrite(_ model: String) async {
+        while pendingWrites[model] == nil {
+            await Task.yield()
+        }
+    }
+
     func readModel(instanceId: String, variantId: String?) async throws -> AgentModelSnapshot {
         if holdsReads {
             await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
@@ -46,6 +62,11 @@ private actor ScriptedModelService: AgentModelServing {
         instanceId: String,
         variantId: String?
     ) async throws -> AgentModelSnapshot {
+        if holdsWrites {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                pendingWrites[model] = continuation
+            }
+        }
         serverModel = model
         return AgentModelSnapshot(model: model, available: catalogue)
     }
@@ -82,6 +103,32 @@ final class AgentModelStoreSyncRaceTests: XCTestCase {
         XCTAssertEqual(store.selectedId, "openai/gpt-5.6-sol")
         // The catalogue is not a member's choice, so the read still delivers it.
         XCTAssertEqual(store.options.map(\.id), catalogue.map(\.id))
+    }
+
+    /// Another member's switch arriving mid-write is not thrown away when the
+    /// write lands. Both devices write the group's appData, so the room can
+    /// converge on theirs — and when it does, the value the room carries is the
+    /// one already observed here, so no further change arrives to correct a
+    /// picker that kept the local tap.
+    func testSyncedModelDuringWriteIsAdoptedWhenTheWriteLands() async {
+        let service = ScriptedModelService(serverModel: nil, catalogue: catalogue)
+        await service.holdWrites(true)
+        let store = AgentModelStore(
+            instanceId: "instance-1",
+            service: service
+        )
+
+        store.select(catalogue[0])
+        await service.waitForPendingWrite(catalogue[0].id)
+        store.apply(syncedModel: catalogue[1].id)
+        // Held, not adopted: the write this device made is still unanswered.
+        XCTAssertEqual(store.selectedId, catalogue[0].id)
+
+        await service.releaseWrite(catalogue[0].id)
+        while store.selectedId == catalogue[0].id {
+            await Task.yield()
+        }
+        XCTAssertEqual(store.selectedId, catalogue[1].id)
     }
 
     /// The room clearing a model is a value like any other: a read that was


### PR DESCRIPTION
A model switch from another device that arrives while this one has its own write in flight is held as `deferredSyncedModel`, then dropped when that write is acknowledged. Preferring the local tap is right — it is the newer intent — but *discarding* the remote value is not, because nothing brings it back.

### Why it does not repair itself

Both devices write the group's appData, so the room converges on whichever commit ordered last. When that is the other member's:

- appData already carries their value,
- the control plane's republish is therefore **identical to what this device already observed**,
- `.onChange(of: syncedModel)` does not fire, and
- no further change arrives to correct a picker still showing the local tap.

The member sees one model while everyone else — and the agent — sees another, until the card is closed and reopened.

### The fix

The deferred value is adopted when the write lands and nothing newer is in flight, instead of being cleared. That can briefly show a model the room then moves off; the next synced change corrects that. Divergence does not correct itself.

Pinned by `testSyncedModelDuringWriteIsAdoptedWhenTheWriteLands`, which holds the write open on a continuation so the remote value provably arrives mid-write, asserts it is *not* adopted while the write is outstanding, then releases and asserts it is.

### Provenance

Raised by Macroscope on #1451 and initially dismissed by me, on the argument that the control plane's republish would deliver the value anyway. That argument was wrong for the case above — the republish carries a value this device has already seen, so there is nothing for `.onChange` to notice. Split out of #1451 rather than merged into it, since that PR had already gone green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790466204&installation_model_id=20076&pr_number=1460&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1460&signature=eed82cff2f26eed7568406369807f5871e712cf5ca8fe5ad65046dd750a244c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `AgentModelStore` to adopt synced model during a local write
> - When a synced model change arrives while a local write is in flight, the store previously discarded the deferred value. Now, if `deferredSyncedModel` exists and `writesInFlight == 1`, the store sets both `selectedId` and `confirmedId` to the deferred synced value instead of clearing it.
> - Adds write-hold support to `ScriptedModelService` (`holdWrites`, `releaseWrite`, `waitForPendingWrite`) and a test confirming the store adopts the synced model once the held write completes.
> - Risk: if a synced value arrives concurrently with multiple in-flight writes (`writesInFlight > 1`), the deferred value is still discarded as before — only the last completing write adopts it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e57e0e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->