### PR TITLE
Route connection grant/revoke events to the agent DM

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -2510,13 +2510,13 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             }
             revokedServiceIds.append(serviceId)
             let providerId = ProviderID(rawValue: "composio.\(serviceId)")
-            // Revoke text is a complete sentence ("Calendar connection
-            // removed") rendered conversation-level, so grantedToInboxId
-            // stays nil — same as the conversation-info revoke path.
+            // The agent inbox id is what lets the event route to the agent's
+            // DM instead of the shared group transcript; when no DM exists the
+            // router falls back to sending here, conversation-level.
             try? await eventWriter.sendRevoked(
                 providerId: providerId.rawValue,
                 capability: nil,
-                grantedToInboxId: nil,
+                grantedToInboxId: grantedToInboxId,
                 in: conversationId
             )
             do {

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionManager.swift
@@ -166,7 +166,7 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
         await postRevocationSideEffects(
             connectionId: connectionId,
             serviceId: serviceId,
-            conversationIds: Array(Set(affectedGrants.map(\.conversationId)))
+            grants: affectedGrants
         )
 
         // Idempotent: GRDB's deleteOne returns false when the row is already
@@ -225,15 +225,10 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
         await republishRevokedGrants(orphanedGrants, context: "during refresh")
 
         for orphan in orphanedConnections {
-            let conversationIds = Array(Set(
-                orphanedGrants
-                    .filter { $0.connectionId == orphan.id }
-                    .map(\.conversationId)
-            ))
             await postRevocationSideEffects(
                 connectionId: orphan.id,
                 serviceId: orphan.serviceId,
-                conversationIds: conversationIds
+                grants: orphanedGrants.filter { $0.connectionId == orphan.id }
             )
         }
 
@@ -351,27 +346,33 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
     private func postRevocationSideEffects(
         connectionId: String,
         serviceId: String?,
-        conversationIds: [String]
+        grants: [DBCloudConnectionGrant]
     ) async {
         guard let serviceId else { return }
         let providerId = ProviderID(rawValue: "composio.\(serviceId)")
         if let eventWriter = eventWriterProvider() {
-            for conversationId in conversationIds {
+            // One revoked event per (conversation, agent) grant rather than one
+            // per conversation: the agent inbox id is what lets the event route
+            // to that agent's DM instead of the shared group transcript.
+            var seenTargets: Set<String> = []
+            for grant in grants {
+                let target = "\(grant.conversationId)|\(grant.grantedToInboxId)"
+                guard seenTargets.insert(target).inserted else { continue }
                 do {
                     try await eventWriter.sendRevoked(
                         providerId: providerId.rawValue,
                         capability: nil,
-                        grantedToInboxId: nil,
-                        in: conversationId
+                        grantedToInboxId: grant.grantedToInboxId,
+                        in: grant.conversationId
                     )
                 } catch {
-                    Log.warning("Failed to send connection_event revoked (connectionId=\(connectionId), conversationId=\(conversationId)): \(error.localizedDescription)")
+                    Log.warning("Failed to send connection_event revoked (connectionId=\(connectionId), conversationId=\(grant.conversationId)): \(error.localizedDescription)")
                 }
             }
-        } else if !conversationIds.isEmpty {
+        } else if !grants.isEmpty {
             Log.warning(
                 "Revocation had no event writer injected; connection_event.revoked " +
-                "will not be posted to \(conversationIds.count) conversation(s) (connectionId=\(connectionId))"
+                "will not be posted for \(grants.count) grant(s) (connectionId=\(connectionId))"
             )
         }
         if let resolver = resolverProvider() {

--- a/ConvosCore/Sources/ConvosCore/Connections/ConnectionEventCodec.swift
+++ b/ConvosCore/Sources/ConvosCore/Connections/ConnectionEventCodec.swift
@@ -23,23 +23,30 @@ public struct ConnectionEvent: Codable, Sendable, Hashable {
     /// is meaningful — e.g. the user disconnected the underlying OAuth) can
     /// continue to omit it.
     public let grantedToInboxId: String?
+    /// Marks a human-facing discoverability copy of an event whose full version
+    /// went to the agent DM. Render-only by contract: agent runtimes neither
+    /// open a turn for it nor relay it to the model. Optional on the wire so
+    /// older receivers ignore it and normal events omit it entirely.
+    public let notice: Bool?
 
     public init(
         version: Int = ConnectionEvent.supportedVersion,
         providerId: String,
         action: Action,
         capability: ConnectionCapability? = nil,
-        grantedToInboxId: String? = nil
+        grantedToInboxId: String? = nil,
+        notice: Bool? = nil
     ) {
         self.version = version
         self.providerId = providerId
         self.action = action
         self.capability = capability
         self.grantedToInboxId = grantedToInboxId
+        self.notice = notice
     }
 
     private enum CodingKeys: String, CodingKey {
-        case version, providerId, action, capability, grantedToInboxId
+        case version, providerId, action, capability, grantedToInboxId, notice
     }
 
     public init(from decoder: Decoder) throws {
@@ -49,6 +56,7 @@ public struct ConnectionEvent: Codable, Sendable, Hashable {
         self.action = try container.decode(Action.self, forKey: .action)
         self.capability = try container.decodeIfPresent(ConnectionCapability.self, forKey: .capability)
         self.grantedToInboxId = try container.decodeIfPresent(String.self, forKey: .grantedToInboxId)
+        self.notice = try container.decodeIfPresent(Bool.self, forKey: .notice)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -58,6 +66,7 @@ public struct ConnectionEvent: Codable, Sendable, Hashable {
         try container.encode(action, forKey: .action)
         try container.encodeIfPresent(capability, forKey: .capability)
         try container.encodeIfPresent(grantedToInboxId, forKey: .grantedToInboxId)
+        try container.encodeIfPresent(notice, forKey: .notice)
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Connections/ConnectionEventRouter.swift
+++ b/ConvosCore/Sources/ConvosCore/Connections/ConnectionEventRouter.swift
@@ -1,0 +1,115 @@
+import ConvosConnections
+import Foundation
+import GRDB
+
+/// Routes connection grant/revoke events to the agent DM instead of the group
+/// the grant was made from, so the transcript humans share isn't the agent's
+/// audit log.
+///
+/// Callers keep addressing the origin conversation (the group the grant is
+/// scoped to) through `ConnectionEventWriterProtocol`, exactly as before; the
+/// router decides where the event actually lands:
+/// - **Granted, agent DM known:** the full event goes to the DM, and a
+///   grantee-less copy tagged `notice: true` goes to the origin group for
+///   discoverability. The notice is render-only by contract — agent runtimes
+///   drop it before it reaches the model.
+/// - **Revoked, agent DM known:** the full event goes to the DM only.
+/// - **No `grantedToInboxId`, no resolvable DM, or the DM send fails:** the
+///   full event goes to the origin conversation — today's behavior, so events
+///   never get lost while DM links are still propagating.
+final class ConnectionEventRouter: ConnectionEventWriterProtocol, Sendable {
+    private let sender: any ConnectionEventSending
+    private let resolveAgentDm: @Sendable (_ agentInboxId: String, _ originConversationId: String) async -> String?
+
+    init(
+        sender: any ConnectionEventSending,
+        resolveAgentDm: @escaping @Sendable (_ agentInboxId: String, _ originConversationId: String) async -> String?
+    ) {
+        self.sender = sender
+        self.resolveAgentDm = resolveAgentDm
+    }
+
+    convenience init(sender: any ConnectionEventSending, databaseReader: any DatabaseReader) {
+        self.init(sender: sender) { agentInboxId, originConversationId in
+            let resolved: String?? = try? await databaseReader.read { db in
+                try DBAgentDmOrigin.dmConversationId(
+                    forOrigin: originConversationId,
+                    agentInboxId: agentInboxId,
+                    in: db
+                )
+            }
+            return resolved.flatMap { $0 }
+        }
+    }
+
+    func sendGranted(
+        providerId: String,
+        capability: ConnectionCapability?,
+        grantedToInboxId: String?,
+        in conversationId: String
+    ) async throws {
+        try await route(
+            ConnectionEvent(
+                providerId: providerId,
+                action: .granted,
+                capability: capability,
+                grantedToInboxId: grantedToInboxId
+            ),
+            from: conversationId
+        )
+    }
+
+    func sendRevoked(
+        providerId: String,
+        capability: ConnectionCapability?,
+        grantedToInboxId: String?,
+        in conversationId: String
+    ) async throws {
+        try await route(
+            ConnectionEvent(
+                providerId: providerId,
+                action: .revoked,
+                capability: capability,
+                grantedToInboxId: grantedToInboxId
+            ),
+            from: conversationId
+        )
+    }
+
+    private func route(_ event: ConnectionEvent, from conversationId: String) async throws {
+        guard let agentInboxId = event.grantedToInboxId, !agentInboxId.isEmpty,
+              let dmConversationId = await resolveAgentDm(agentInboxId, conversationId),
+              dmConversationId != conversationId else {
+            try await sender.send(event, in: conversationId)
+            return
+        }
+
+        do {
+            try await sender.send(event, in: dmConversationId)
+        } catch {
+            Log.warning(
+                "[connections] DM route failed for \(event.action.rawValue) \(event.providerId); " +
+                "falling back to \(conversationId): \(error)"
+            )
+            try await sender.send(event, in: conversationId)
+            return
+        }
+
+        guard event.action == .granted else { return }
+        // Discoverability line in the group. Best-effort: the authoritative
+        // event already landed in the DM, so a failed copy shouldn't fail the
+        // grant flow.
+        let notice = ConnectionEvent(
+            providerId: event.providerId,
+            action: .granted,
+            capability: event.capability,
+            grantedToInboxId: nil,
+            notice: true
+        )
+        do {
+            try await sender.send(notice, in: conversationId)
+        } catch {
+            Log.warning("[connections] notice copy failed for \(event.providerId) in \(conversationId): \(error)")
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Connections/ConnectionEventWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Connections/ConnectionEventWriter.swift
@@ -37,7 +37,15 @@ public enum ConnectionEventWriterError: Error, LocalizedError {
     }
 }
 
-final class ConnectionEventWriter: ConnectionEventWriterProtocol, Sendable {
+/// The raw single-conversation send underneath the writer protocol. Split out
+/// so `ConnectionEventRouter` can fan a fully-formed event (including the
+/// `notice` copy) into a specific conversation without re-deriving it from the
+/// protocol's granted/revoked parameters.
+protocol ConnectionEventSending: Sendable {
+    func send(_ event: ConnectionEvent, in conversationId: String) async throws
+}
+
+final class ConnectionEventWriter: ConnectionEventWriterProtocol, ConnectionEventSending, Sendable {
     private let sessionStateManager: any SessionStateManagerProtocol
 
     init(sessionStateManager: any SessionStateManagerProtocol) {
@@ -50,11 +58,13 @@ final class ConnectionEventWriter: ConnectionEventWriterProtocol, Sendable {
         grantedToInboxId: String?,
         in conversationId: String
     ) async throws {
-        try await sendEvent(
-            .granted,
-            providerId: providerId,
-            capability: capability,
-            grantedToInboxId: grantedToInboxId,
+        try await send(
+            ConnectionEvent(
+                providerId: providerId,
+                action: .granted,
+                capability: capability,
+                grantedToInboxId: grantedToInboxId
+            ),
             in: conversationId
         )
     }
@@ -65,22 +75,18 @@ final class ConnectionEventWriter: ConnectionEventWriterProtocol, Sendable {
         grantedToInboxId: String?,
         in conversationId: String
     ) async throws {
-        try await sendEvent(
-            .revoked,
-            providerId: providerId,
-            capability: capability,
-            grantedToInboxId: grantedToInboxId,
+        try await send(
+            ConnectionEvent(
+                providerId: providerId,
+                action: .revoked,
+                capability: capability,
+                grantedToInboxId: grantedToInboxId
+            ),
             in: conversationId
         )
     }
 
-    private func sendEvent(
-        _ action: ConnectionEvent.Action,
-        providerId: String,
-        capability: ConnectionCapability?,
-        grantedToInboxId: String?,
-        in conversationId: String
-    ) async throws {
+    func send(_ event: ConnectionEvent, in conversationId: String) async throws {
         let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
         let client = inboxReady.client
 
@@ -88,12 +94,6 @@ final class ConnectionEventWriter: ConnectionEventWriterProtocol, Sendable {
             throw ConnectionEventWriterError.conversationNotFound(conversationId: conversationId)
         }
 
-        let event = ConnectionEvent(
-            providerId: providerId,
-            action: action,
-            capability: capability,
-            grantedToInboxId: grantedToInboxId
-        )
         let encoded = try ConnectionEventCodec().encode(content: event)
         try await conversation.send(encodedContent: encoded)
     }

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -449,7 +449,10 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
     }
 
     func connectionEventWriter() -> any ConnectionEventWriterProtocol {
-        ConnectionEventWriter(sessionStateManager: sessionStateManager)
+        ConnectionEventRouter(
+            sender: ConnectionEventWriter(sessionStateManager: sessionStateManager),
+            databaseReader: databaseReader
+        )
     }
 
     func capabilityRequestResultWriter() -> any CapabilityRequestResultWriterProtocol {

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentDmOrigin.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentDmOrigin.swift
@@ -33,6 +33,31 @@ extension DBAgentDmOrigin {
         try fetchOne(db, key: conversationId)?.originConversationId
     }
 
+    /// The reverse mapping: the agent DM a given agent owns under a given
+    /// origin group, or nil when no such DM is known locally. Verifies the
+    /// candidate is still classified as an agent DM and that the agent is a
+    /// member, so a stale link never routes an event into the wrong
+    /// conversation.
+    static func dmConversationId(
+        forOrigin originConversationId: String,
+        agentInboxId: String,
+        in db: Database
+    ) throws -> String? {
+        let links = try DBAgentDmOrigin
+            .filter(Columns.originConversationId == originConversationId)
+            .fetchAll(db)
+        for link in links {
+            guard let conversation = try DBConversation.fetchOne(db, key: link.conversationId),
+                  conversation.isAgentDm else { continue }
+            let isMember = try DBConversationMember
+                .filter(DBConversationMember.Columns.conversationId == link.conversationId)
+                .filter(DBConversationMember.Columns.inboxId == agentInboxId)
+                .fetchCount(db) > 0
+            if isMember { return link.conversationId }
+        }
+        return nil
+    }
+
     /// Records (or replaces) the DM -> parent link. No-op when `originConversationId`
     /// is nil or empty so a marker written without an origin never clears a good one.
     static func record(conversationId: String, originConversationId: String?, in db: Database) throws {

--- a/ConvosCore/Tests/ConvosCoreTests/AgentDmTapRoutingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentDmTapRoutingTests.swift
@@ -139,4 +139,54 @@ struct AgentDmTapRoutingTests {
             #expect(try DBAgentDmOrigin.originConversationId(for: "unknown", in: db) == nil)
         }
     }
+
+    @Test("The reverse lookup resolves the agent's DM under an origin group")
+    func reverseLookupResolvesDm() throws {
+        let queue = try Self.migratedQueue()
+        try queue.write { try Self.seed($0) }
+
+        let resolved = try queue.read { db in
+            try DBAgentDmOrigin.dmConversationId(
+                forOrigin: Self.parentId, agentInboxId: Self.agentInboxId, in: db
+            )
+        }
+        #expect(resolved == Self.dmId)
+    }
+
+    @Test("The reverse lookup rejects a non-member agent and an unknown origin")
+    func reverseLookupRejectsMismatches() throws {
+        let queue = try Self.migratedQueue()
+        try queue.write { try Self.seed($0) }
+
+        let nonMember = try queue.read { db in
+            try DBAgentDmOrigin.dmConversationId(
+                forOrigin: Self.parentId, agentInboxId: "inbox-other", in: db
+            )
+        }
+        #expect(nonMember == nil)
+
+        let unknownOrigin = try queue.read { db in
+            try DBAgentDmOrigin.dmConversationId(
+                forOrigin: "unknown-group", agentInboxId: Self.agentInboxId, in: db
+            )
+        }
+        #expect(unknownOrigin == nil)
+    }
+
+    @Test("The reverse lookup ignores a link whose conversation is no longer an agent DM")
+    func reverseLookupIgnoresNonDmLink() throws {
+        let queue = try Self.migratedQueue()
+        try queue.write { db in
+            try Self.seed(db, withOrigin: false)
+            // A stale link pointing at a plain group must not route events there.
+            try DBAgentDmOrigin.record(conversationId: Self.parentId, originConversationId: "some-group", in: db)
+        }
+
+        let resolved = try queue.read { db in
+            try DBAgentDmOrigin.dmConversationId(
+                forOrigin: "some-group", agentInboxId: Self.agentInboxId, in: db
+            )
+        }
+        #expect(resolved == nil)
+    }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionEventCodecTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionEventCodecTests.swift
@@ -58,6 +58,28 @@ struct ConnectionEventCodecTests {
         }
         #expect(!json.contains("capability"))
     }
+
+    @Test("round-trips the notice marker and omits it when nil")
+    func roundTripsNotice() throws {
+        let codec = ConnectionEventCodec()
+        let notice = ConnectionEvent(
+            providerId: "composio.googlecalendar",
+            action: .granted,
+            notice: true
+        )
+        let decoded = try codec.decode(content: codec.encode(content: notice))
+        #expect(decoded.notice == true)
+        #expect(decoded == notice)
+
+        let plain = ConnectionEvent(providerId: "composio.googlecalendar", action: .granted)
+        let data = try JSONEncoder().encode(plain)
+        guard let json = String(data: data, encoding: .utf8) else {
+            Issue.record("Failed to decode JSON output")
+            return
+        }
+        #expect(!json.contains("notice"), "Normal events must stay byte-identical for old receivers")
+        #expect(try JSONDecoder().decode(ConnectionEvent.self, from: data).notice == nil)
+    }
 }
 
 @Suite("ConnectionMessageSummaryFormatter capability text")

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionEventRouterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionEventRouterTests.swift
@@ -1,0 +1,178 @@
+import ConvosConnections
+@testable import ConvosCore
+import Foundation
+import Testing
+
+@Suite("ConnectionEventRouter")
+struct ConnectionEventRouterTests {
+    private static let agent: String = "agent-inbox"
+    private static let origin: String = "origin-group"
+    private static let dm: String = "agent-dm"
+
+    private actor RecordingSender: ConnectionEventSending {
+        struct Sent: Equatable {
+            let event: ConnectionEvent
+            let conversationId: String
+        }
+
+        private(set) var sent: [Sent] = []
+        var failFor: Set<String> = []
+
+        func setFailing(_ conversationIds: Set<String>) {
+            failFor = conversationIds
+        }
+
+        func send(_ event: ConnectionEvent, in conversationId: String) async throws {
+            if failFor.contains(conversationId) {
+                throw ConnectionEventWriterError.conversationNotFound(conversationId: conversationId)
+            }
+            sent.append(Sent(event: event, conversationId: conversationId))
+        }
+
+        func allSent() -> [Sent] { sent }
+    }
+
+    private func makeRouter(
+        sender: RecordingSender,
+        dmByAgentAndOrigin: [String: String]
+    ) -> ConnectionEventRouter {
+        ConnectionEventRouter(sender: sender) { agentInboxId, originConversationId in
+            dmByAgentAndOrigin["\(agentInboxId)|\(originConversationId)"]
+        }
+    }
+
+    @Test("granted with a known DM sends the full event to the DM and a notice copy to the group")
+    func grantedRoutesToDmWithGroupNotice() async throws {
+        let sender = RecordingSender()
+        let router = makeRouter(sender: sender, dmByAgentAndOrigin: ["\(Self.agent)|\(Self.origin)": Self.dm])
+
+        try await router.sendGranted(
+            providerId: "composio.googlecalendar",
+            capability: nil,
+            grantedToInboxId: Self.agent,
+            in: Self.origin
+        )
+
+        let sent = await sender.allSent()
+        #expect(sent.count == 2)
+        #expect(sent[0].conversationId == Self.dm)
+        #expect(sent[0].event.grantedToInboxId == Self.agent)
+        #expect(sent[0].event.notice == nil)
+        #expect(sent[1].conversationId == Self.origin)
+        #expect(sent[1].event.notice == true)
+        #expect(sent[1].event.grantedToInboxId == nil, "The group copy is grantee-less discoverability text")
+        #expect(sent[1].event.action == .granted)
+    }
+
+    @Test("revoked with a known DM sends only the full event to the DM")
+    func revokedRoutesToDmOnly() async throws {
+        let sender = RecordingSender()
+        let router = makeRouter(sender: sender, dmByAgentAndOrigin: ["\(Self.agent)|\(Self.origin)": Self.dm])
+
+        try await router.sendRevoked(
+            providerId: "composio.googlecalendar",
+            capability: nil,
+            grantedToInboxId: Self.agent,
+            in: Self.origin
+        )
+
+        let sent = await sender.allSent()
+        #expect(sent.count == 1)
+        #expect(sent[0].conversationId == Self.dm)
+        #expect(sent[0].event.action == .revoked)
+        #expect(sent[0].event.notice == nil)
+    }
+
+    @Test("no grantee falls back to the origin conversation")
+    func noGranteeSendsToOrigin() async throws {
+        let sender = RecordingSender()
+        let router = makeRouter(sender: sender, dmByAgentAndOrigin: ["\(Self.agent)|\(Self.origin)": Self.dm])
+
+        try await router.sendRevoked(
+            providerId: "composio.googlecalendar",
+            capability: nil,
+            grantedToInboxId: nil,
+            in: Self.origin
+        )
+
+        let sent = await sender.allSent()
+        #expect(sent.count == 1)
+        #expect(sent[0].conversationId == Self.origin)
+        #expect(sent[0].event.notice == nil)
+    }
+
+    @Test("unresolvable DM falls back to the origin conversation without a notice")
+    func unresolvableDmSendsToOrigin() async throws {
+        let sender = RecordingSender()
+        let router = makeRouter(sender: sender, dmByAgentAndOrigin: [:])
+
+        try await router.sendGranted(
+            providerId: "composio.googlecalendar",
+            capability: nil,
+            grantedToInboxId: Self.agent,
+            in: Self.origin
+        )
+
+        let sent = await sender.allSent()
+        #expect(sent.count == 1)
+        #expect(sent[0].conversationId == Self.origin)
+        #expect(sent[0].event.grantedToInboxId == Self.agent)
+        #expect(sent[0].event.notice == nil)
+    }
+
+    @Test("a DM resolving to the sending conversation itself sends one event, no copy")
+    func dmEqualToOriginSendsOnce() async throws {
+        let sender = RecordingSender()
+        let router = makeRouter(sender: sender, dmByAgentAndOrigin: ["\(Self.agent)|\(Self.dm)": Self.dm])
+
+        try await router.sendGranted(
+            providerId: "composio.googlecalendar",
+            capability: nil,
+            grantedToInboxId: Self.agent,
+            in: Self.dm
+        )
+
+        let sent = await sender.allSent()
+        #expect(sent.count == 1)
+        #expect(sent[0].conversationId == Self.dm)
+        #expect(sent[0].event.notice == nil)
+    }
+
+    @Test("a failed DM send falls back to the full event in the origin conversation")
+    func failedDmSendFallsBack() async throws {
+        let sender = RecordingSender()
+        await sender.setFailing([Self.dm])
+        let router = makeRouter(sender: sender, dmByAgentAndOrigin: ["\(Self.agent)|\(Self.origin)": Self.dm])
+
+        try await router.sendGranted(
+            providerId: "composio.googlecalendar",
+            capability: nil,
+            grantedToInboxId: Self.agent,
+            in: Self.origin
+        )
+
+        let sent = await sender.allSent()
+        #expect(sent.count == 1)
+        #expect(sent[0].conversationId == Self.origin)
+        #expect(sent[0].event.grantedToInboxId == Self.agent)
+        #expect(sent[0].event.notice == nil, "The fallback is the authoritative event, not a notice copy")
+    }
+
+    @Test("a failed notice copy does not fail the grant flow")
+    func failedNoticeCopyIsSwallowed() async throws {
+        let sender = RecordingSender()
+        await sender.setFailing([Self.origin])
+        let router = makeRouter(sender: sender, dmByAgentAndOrigin: ["\(Self.agent)|\(Self.origin)": Self.dm])
+
+        try await router.sendGranted(
+            providerId: "composio.googlecalendar",
+            capability: nil,
+            grantedToInboxId: Self.agent,
+            in: Self.origin
+        )
+
+        let sent = await sender.allSent()
+        #expect(sent.count == 1)
+        #expect(sent[0].conversationId == Self.dm)
+    }
+}


### PR DESCRIPTION
## Summary

Connection grant/revoke events currently land in the shared group transcript. This PR routes them to the agent DM instead, keeping the group readable while the agent still sees its authoritative grant ledger:

- **Granted (agent known):** the full `connection_event` goes to the agent's DM, and a grantee-less copy tagged `notice: true` is posted in the origin group for discoverability. The notice is render-only by contract — the assistants runtime opens no turn for it and never relays it to the model.
- **Revoked (agent known):** the full event goes to the DM only.
- **No grantee, no resolvable DM, or a failed DM send:** exactly today's behavior (full event to the group), so events are never lost while DM links are still propagating.

Implementation: `MessagingService.connectionEventWriter()` now returns a `ConnectionEventRouter` conforming to `ConnectionEventWriterProtocol`, so every existing emitter (abilities announcer, capability approvals, agent-builder replayer, revoke paths) routes with no call-site signature changes. DM resolution is a new membership-verified `DBAgentDmOrigin` reverse lookup (origin group + agent inbox id → DM), so a stale link never routes an event into the wrong conversation. `ConnectionEvent` gains an optional `notice` field encoded with `encodeIfPresent` — normal events stay byte-identical on the wire. The Done-revoke and account-disconnect paths now pass the agent inbox ids their grant rows already held (one revoked event per conversation+agent grant) so those events can route too.

Mirror of the convos-client PR of the same name; depends on the convos-assistants `notice` contract (xmtplabs/convos-assistants#3708) being deployed before clients ship — until then this PR must stay unmerged per the deployment plan.

Tests: `ConnectionEventRouterTests` (routing, notice copy, fallbacks), codec round-trip pinning that `notice` is omitted when nil, reverse-lookup tests in `AgentDmTapRoutingTests` (resolution, non-member rejection, stale-link rejection), and the updated `ConnectionManagerTests` still pass against the per-grant revoke fan-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvSn5kjdB9N2GAS9DCpXSG

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790469621&installation_model_id=20076&pr_number=1461&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1461&signature=f079a0775e797d8f6674bb24d9c28c347252154c7f445a1f6e53d691d18e1e56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route connection grant/revoke events to the agent DM via `ConnectionEventRouter`
> - Introduces `ConnectionEventRouter` which resolves an agent's DM conversation and sends full grant/revoke events there; grants also post a best-effort notice copy (with `notice: true`) to the origin group, while revokes do not
> - `MessagingService.connectionEventWriter` now returns a `ConnectionEventRouter` wrapping the existing `ConnectionEventWriter`, so all callers get routed behavior
> - `CloudConnectionManager.postRevocationSideEffects` now accepts grants instead of conversation IDs and emits one revoked event per unique `(conversationId, grantedToInboxId)` pair with the grantee populated
> - Adds optional `notice: Bool?` to `ConnectionEvent` (omitted from JSON when nil) and `DBAgentDmOrigin.dmConversationId(forOrigin:agentInboxId:in:)` reverse lookup that validates the target is still an agent DM with the agent as a member
> - Behavioral Change: grant events previously sent only to the origin group now additionally route to the agent DM; revocation events now carry `grantedToInboxId` and target the DM when resolvable, falling back to the origin group on failure
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ab55203. 7 files reviewed, 3 issues evaluated, 1 issue filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>ConvosCore/Sources/ConvosCore/Connections/ConnectionEventRouter.swift — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 81](https://github.com/xmtplabs/convos-ios/blob/ab5520309cdc2140849d9f075b5c78423bd3571b/ConvosCore/Sources/ConvosCore/Connections/ConnectionEventRouter.swift#L81): The router trusts any ID returned by `resolveAgentDm` and sends the full grant/revoke event there. The production resolver accepts a locally stored `agent_dm_origin` link when the candidate is merely marked `isAgentDm` and contains the target agent; it does not verify that it is a two-party DM or that no unrelated member can read it. The underlying origin marker is explicitly member-writable appData, so a member of another conversation containing the user and agent can mark that conversation with a known origin ID. Subsequent events for that origin are then routed into the attacker-readable conversation, disclosing the connection grant/revoke rather than sending it to the intended DM. <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->