### PR TITLE
Enable libxmtp trace sampling in production (0.05)

### DIFF
--- a/Convos/Config/LibxmtpSentry.swift
+++ b/Convos/Config/LibxmtpSentry.swift
@@ -13,10 +13,10 @@ import XMTPiOS
 /// SDK code. Keeping the whole surface here makes a codegen rename a one-file
 /// fix instead of a scatter of call-site edits.
 enum LibxmtpSentry {
-    /// Production sends no traces: they carry per-operation timing for every
-    /// send and sync, and the volume is not worth paying for until the
-    /// internal builds show which spans are worth keeping.
-    private static let productionTracesSampleRate: Float = 0.0
+    /// Production samples 5% of operations into Sentry performance traces;
+    /// the internal-build soak showed the span set is worth keeping. Error
+    /// events are never sampled — only the waterfalls are.
+    private static let productionTracesSampleRate: Float = 0.05
     private static let internalTracesSampleRate: Float = 0.1
 
     /// Matches the Sentry SDK's own default, and bounds how much libxmtp


### PR DESCRIPTION
Raises `productionTracesSampleRate` from `0.0` to `0.05` — 5% of libxmtp FFI operations ship performance transactions (span waterfalls) to Sentry alongside the error events already flowing in prod. Internal/dev builds have been soaking at 0.1 since #1454.

Error events are unaffected (always sent). Span fields are identity-free by construction; transactions carry `component=libxmtp`. One-line config knob — trivial to lower if prod span volume surprises us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790522313&installation_model_id=20076&pr_number=1463&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1463&signature=cc68da7dd7218fef34d09e3e39a1d0fba1a0d443ad4ffe70af5dc1feced69410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `LibxmtpSentry.productionTracesSampleRate` to 0.05 in production
> Changes the production trace sampling rate from 0% to 5% so that libxmtp operations now send performance traces in production. The constant is read wherever the sampling rate is applied; no other `LibxmtpSentry` members change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 308b155.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->