### PR TITLE
feat(models): the picker is on by default where it is being built

### DIFF
--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -117,16 +117,27 @@ final class FeatureFlags {
         }
     }
 
-    /// Off by default -- gates the model picker on an agent's contact card.
-    /// Reachable in every environment, same posture as the flags above: the
-    /// switch is a real product control meant to be dogfooded on a production
-    /// build, not a dev affordance. Default-off keeps the row absent, and with
-    /// it the catalogue read, so an agent nobody is switching is never asked
-    /// what it can run.
+    /// On by default on internal builds, off by default in production --
+    /// gates the model picker on an agent's contact card. Reachable in every
+    /// environment, same posture as the flags above: the switch is a real
+    /// product control meant to be dogfooded on a production build, not a dev
+    /// affordance. Dev and Local carry the row without anyone opting in, so
+    /// the feature is exercised by default where it is being built; production
+    /// stays default-off, and with it the catalogue read, so an agent nobody
+    /// is switching is never asked what it can run.
+    ///
+    /// The default only applies while nothing is stored: an explicit toggle
+    /// from either debug menu is honoured in both directions, so turning it
+    /// off on a dev build stays off across launches.
     var isAgentModelPickerEnabled: Bool {
         get {
             access(keyPath: \.isAgentModelPickerEnabled)
-            return UserDefaults.standard.bool(forKey: Constant.agentModelPickerEnabledKey)
+            if let stored = UserDefaults.standard.object(
+                forKey: Constant.agentModelPickerEnabledKey
+            ) as? Bool {
+                return stored
+            }
+            return ConfigManager.shared.currentEnvironment.isInternalBuild
         }
         set {
             withMutation(keyPath: \.isAgentModelPickerEnabled) {


### PR DESCRIPTION
The agent model picker on a contact card is gated by `isAgentModelPickerEnabled`, which read straight from `UserDefaults` and so defaulted off everywhere. The switch is now shipped end to end — the picker writes through the control plane, the choice travels in the conversation's app data, and the catalogue is backend data with admin CRUD — so on the builds where it is being developed nobody should have to find a debug toggle first.

Internal builds (`.dev` and `.local`, via the existing `isInternalBuild`) now default the flag on. Production is unchanged and stays default-off, along with the catalogue read behind it.

The read moves from `bool(forKey:)` to `object(forKey:) as? Bool`, because `bool(forKey:)` cannot tell "never set" from "explicitly off". The new default therefore applies only while nothing is stored: turning the picker off from either debug menu on a dev build stays off across launches. The setter and both debug-menu rows are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uzk4fSFyAs6QDv98BPcaoH

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790523577&installation_model_id=20076&pr_number=1465&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1465&signature=928d0bd2234a8280750828c7705ec5a80264acdcedc51da925457270da935567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `isAgentModelPickerEnabled` to true on internal builds
> The `isAgentModelPickerEnabled` getter now falls back to `ConfigManager.shared.currentEnvironment.isInternalBuild` when no UserDefaults Bool is stored, instead of always defaulting to false. Explicitly stored values still take precedence.
>
> Risk: internal builds with no prior UserDefaults value will now show the agent model picker; production builds remain default-disabled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81d9a95.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->